### PR TITLE
Windows suppport + QOL changes

### DIFF
--- a/do_track.bat
+++ b/do_track.bat
@@ -1,0 +1,1 @@
+python matecheck.py --stockfish ./stockfish --nodes 1000000

--- a/matecheck.py
+++ b/matecheck.py
@@ -3,7 +3,7 @@ import argparse
 import concurrent.futures
 import chess.engine
 import chess
-
+from multiprocessing import freeze_support
 
 def chunks(lst, n):
     """Yield successive n-sized chunks from lst."""
@@ -33,48 +33,59 @@ class Analyser:
 
         return result_fens
 
+if __name__ == "__main__":
+    freeze_support()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--stockfish", type=str, default="./stockfish", help="Name of the stockfish binary"
+    )
+    parser.add_argument("--nodes", type=int, default=1000000, help="nodes per pos")
+    args = parser.parse_args()
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--stockfish", type=str, default="./stockfish", help="Name of the stockfish binary"
-)
-parser.add_argument("--nodes", type=int, default=2000000, help="nodes per pos")
-args = parser.parse_args()
+    ana = Analyser(args.stockfish, args.nodes)
 
-ana = Analyser(args.stockfish, args.nodes)
+    p = re.compile("([0-8a-zA-Z/\- ]*) bm #([0-9\-]*);")
+    fens = []
+    
+    print("Loading FENs...")
 
-p = re.compile("([0-8a-zA-Z/\- ]*) bm #([0-9\-]*);")
-fens = []
+    with open(
+        "ChestUCI_23102018.epd", "r", encoding="utf-8-sig", errors="surrogateescape"
+    ) as f:
+        for line in f:
+            m = p.match(line)
+            if not m:
+                print("---------------------> IGNORING : ", line)
+            else:
+                fens.append([m.group(1), int(m.group(2))])
+    
+    print("FENs loaded...")
+    print("Mate track started...")
+    
+    numfen = len(fens)
+    fenschunked = list(chunks(fens, 10))
+    res = []
+    count = 0;
+    if True:
+        with concurrent.futures.ProcessPoolExecutor() as e:
+            results = e.map(ana.analyze_fens, fenschunked)
+            for r in results:
+                count += 10
+                print("\rProgress: %d%%" % (count * 100 / numfen), end="")
+                res = res + r
+        print("\n")
+        
+    mates = 0
+    bestmates = 0
+    bettermates = 0
+    for r in res:
+        if not r[2]:
+            continue
+        mates = mates + 1
+        if abs(r[1]) == abs(r[2]):
+            bestmates = bestmates + 1
 
-with open(
-    "ChestUCI_23102018.epd", "r", encoding="utf-8-sig", errors="surrogateescape"
-) as f:
-    for line in f:
-        m = p.match(line)
-        if not m:
-            print("---------------------> IGNORING : ", line)
-        else:
-            fens.append([m.group(1), int(m.group(2))])
-
-fenschunked = list(chunks(fens, 10))
-res = []
-if True:
-    with concurrent.futures.ProcessPoolExecutor() as e:
-        results = e.map(ana.analyze_fens, fenschunked)
-        for r in results:
-            res = res + r
-
-mates = 0
-bestmates = 0
-bettermates = 0
-for r in res:
-    if not r[2]:
-        continue
-    mates = mates + 1
-    if abs(r[1]) == abs(r[2]):
-        bestmates = bestmates + 1
-
-print("Using %s with %d nodes" % (args.stockfish, args.nodes))
-print("Total fens:   ", len(fens))
-print("Found mates:  ", mates)
-print("Best mates:   ", bestmates)
+    print("Using %s with %d nodes" % (args.stockfish, args.nodes))
+    print("Total fens:   ", numfen)
+    print("Found mates:  ", mates)
+    print("Best mates:   ", bestmates)


### PR DESCRIPTION
This adds support for windows, which needs `freeze_support()` also a simple `.bat` file to start matetrack for normal windows users.
Also additional output while its running.
Example:

    Loading FENs...
    FENs loaded...
    Mate track started...
    Progress: 100%
    
    Using ./stockfish with 100 nodes
    Total fens:    6566
    Found mates:   7
    Best mates:    7

Where as `Progress` goes from 0% to 100%. Where as before it was more like a blackbox with no estimate of how many fen's it still needs to analyze.