### PR TITLE
bigger fen chunks

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -3,7 +3,8 @@ import argparse
 import concurrent.futures
 import chess.engine
 import chess
-from multiprocessing import freeze_support
+from time import time
+from multiprocessing import freeze_support, cpu_count
 
 def chunks(lst, n):
     """Yield successive n-sized chunks from lst."""
@@ -60,24 +61,29 @@ if __name__ == "__main__":
                 fens.append([m.group(1), int(m.group(2))])
     
     print("FENs loaded...")
-    print("Mate track started...")
     
     numfen = len(fens)
-    fenschunked = list(chunks(fens, 10))
+    workers = cpu_count()
+    fw_ratio = numfen/workers
+    fenschunked = list(chunks(fens, int(fw_ratio)))
+
+    print("\nMatetrack started...")
+    
     res = []
     count = 0;
+    t0 = time()
+    print("\rProgress: 0%", end="")
     if True:
         with concurrent.futures.ProcessPoolExecutor() as e:
             results = e.map(ana.analyze_fens, fenschunked)
             for r in results:
-                count += 10
-                print("\rProgress: %d%%" % (count * 100 / numfen), end="")
+                count += fw_ratio
+                print("\rProgress: %d%%" % min(count * 100 / numfen, 100), end="")
                 res = res + r
-        print("\n")
+    print("\nCompleted in:", str(time() - t0) + " seconds\n" ) 
         
     mates = 0
     bestmates = 0
-    bettermates = 0
     for r in res:
         if not r[2]:
             continue


### PR DESCRIPTION
Each process will have a bigger chunk of fens to analyse, this increases the performance most notably for lower nodes.

New sample output using 12 threads:

    Loading FENs...
    FENs loaded...
    
    Matetrack started...
    Progress: 100%
    Completed in: 14.999129056930542 seconds
    
    Using ./stockfish with 1000 nodes
    Total fens:    6566
    Found mates:   60
    Best mates:    34

Before it took 28.8 seconds.

This effect decreases with a higher nodes limit but is still measurable.
Changing `numfen/workers` to `numfen/(workers * 2)` resulted in roughly the same time.
`fenschunked` was actually divided in 13 chunks, but moving
the remaining fens into the last chunk resulted in roughly the same time again.

`Progress:  ` still works but is mostly at 0% because each process will finish in about the same time.