### PR TITLE
replace modern arch

### DIFF
--- a/do_track.sh
+++ b/do_track.sh
@@ -39,7 +39,7 @@ do
       git checkout $rev >& checkout2.log
       epoch=`git show --pretty=fuller --date=short $rev | grep 'CommitDate' | awk '{print $NF}'`
       make clean >& clean.log
-      make -j ARCH=x86-64-modern profile-build >& make.log
+      CXXFLAGS='-march=native' make -j ARCH=x86-64-avx2 profile-build >& make.log
       mv stockfish ../..
       cd ../..
 


### PR DESCRIPTION
Replace depreciated arch. Also add `-march` flag for small speed-up and as an example for others on how to use it.

@vondele Does the machine on which you run the analysis support `x86-64-avx2`?