### PR TITLE
clean up of matecheck.py

### DIFF
--- a/do_track.bat
+++ b/do_track.bat
@@ -1,1 +1,0 @@
-python matecheck.py --stockfish ./stockfish --nodes 1000000

--- a/matecheck.bat
+++ b/matecheck.bat
@@ -1,0 +1,1 @@
+python matecheck.py --engine ./stockfish --nodes 1000000


### PR DESCRIPTION
This is a small clean up of the code base, with the following non-trivial changes:

1. Allow for the digit `9` in the pattern matching to allow possible move counters in future positions.
2. The option `--stockfish` has been renamed to `--engine`. Let me know if for backward compatibility we need to keep also `--stockfish`.
3. The new option `--epdFile` allows the check to be run on a different file than `matetrack.epd`.
4. The automatic `black` formatting has been applied.
5. The file `do_track.bat` has been renamed to `matecheck.bat`, as this better reflects what it is doing. Hope this is fine for @Disservin.
6. The best mate check is now done without using `abs`. I have checked all occurrences of negative `mate` or `bestmate` for a run with current SF master on `matetrack.epd`, and in all cases the signs always agreed.
7. I simplified away the utf encoding handling, as it does not seem necessary for the `.epd` files we have in mind.