### PR TITLE
save output with wrong PVs

### DIFF
--- a/do_track.sh
+++ b/do_track.sh
@@ -89,8 +89,8 @@ for rev in $revs; do
             mates=$(grep "Found mates:" $out | awk '{print $NF}')
             bmates=$(grep "Best mates:" $out | awk '{print $NF}')
 
-            # save incorrect and better mates for possible debugging
-            if grep -q "\(Wrong\|Better\) mates:" $out; then
+            # save wrong/better mates and wrong PVs for possible debugging
+            if grep -q "\(Wrong\|Better\|PV status\)" $out; then
                 mv $out out$nodes.$rev
             fi
         else


### PR DESCRIPTION
This PR also keeps outputs from matetrack runs that lead to incorrect PVs.