### PR TITLE
add test_engine.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
 	black --quiet matecheck.py plotdata.py
-	shfmt -w -i 4 do_track.sh
+	shfmt -w -i 4 do_track.sh test_engine.sh
 
 all: format

--- a/test_engine.sh
+++ b/test_engine.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+ENGINE=./stockfish
+EPD=matetrack.epd
+THREADS=1
+ITERATIONS=6
+
+# Parse command line options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    --engine)
+        ENGINE="$2"
+        shift
+        ;;
+    --epdFile)
+        EPD="$2"
+        shift
+        ;;
+    --threads)
+        THREADS="$2"
+        shift
+        ;;
+    --iterations)
+        ITERATIONS="$2"
+        shift
+        ;;
+    --help)
+        echo "Usage: $0 --engine <engine> --epdFile <epdFile> --threads <threads> --iterations <iterations>"
+        echo ""
+        echo "Options:"
+        echo "  --engine      parameter passed to matecheck.py (default: ./stockfish)"
+        echo "  --epdFile     parameter passed to matecheck.py (default: matetrack.epd)"
+        echo "  --threads     parameter passed to matecheck.py (default: 1)"
+        echo "  --iterations  maximal power of 10 to use for --nodes (default: 6)"
+        echo ""
+        echo "The script checks if an engine reports correct mate scores from aborted searches."
+        echo "Transient(!) 'better' mates reported by an engine may indicate a bug."
+        echo "However, a lack of such mates being reported is not a guarantee that the engine handles all mate scores correctly."
+        exit 0
+        ;;
+    *)
+        echo "Unknown parameter passed: $1"
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+EPD=${EPD%.epd}
+
+echo "Running $ENGINE on ${EPD}.epd with --threads $THREADS"
+
+for p in $(seq 1 $ITERATIONS); do
+    nodes=$((10 ** p))
+    out="${ENGINE}_${EPD}_threads${THREADS}_nodes1e${p}.log"
+    python matecheck.py --epdFile "${EPD}.epd" --engine "$ENGINE" --nodes "$nodes" --threads "$THREADS" >&"$out"
+    echo "--nodes $nodes done, output saved to $out"
+    grep "\(better\|wrong\|PV:\)" "$out"
+done


### PR DESCRIPTION
I am not 100% sure the repo is the right place for this script, but it proved very useful in recent SF development, together with the `matedtrack.epd` file from https://github.com/vondele/matetrack/pull/25.

I think it could be useful for engine developers in general.

Sample output as provided in https://github.com/official-stockfish/Stockfish/pull/4976:

```
Running ./master on matedtrack.epd with --threads 1
--nodes 10 done, output saved to ./master_matedtrack_threads1_nodes1e1.log
--nodes 100 done, output saved to ./master_matedtrack_threads1_nodes1e2.log
--nodes 1000 done, output saved to ./master_matedtrack_threads1_nodes1e3.log
Found mate #-2 (better) for FEN "k7/n1RN4/B7/8/K7/4n3/8/8 b - -".
PV: a7c6 d7b6 a8b8 c7b7
Found mate #-2 (better) for FEN "2b5/2N2p2/6p1/4N3/1B1k1p1r/Kp6/n7/3Q4 b - -".
PV: d4e5 d1d5 e5f6 c7e8
--nodes 10000 done, output saved to ./master_matedtrack_threads1_nodes1e4.log
Found mate #-6 (better) for FEN "8/8/8/4p3/5B2/6p1/7k/4KBN1 b - -".
PV: h2h1 f4g3 e5e4 g3f4 h1g1 f4e3 g1h2 e1f2 h2h1 f1g2 h1h2 e3f4
--nodes 100000 done, output saved to ./master_matedtrack_threads1_nodes1e5.log
Found mate #-4 (better) for FEN "5Kn1/5pQ1/7p/8/4NB1p/p2B3p/qpNp2p1/2rrb1kb b - -".
PV: a2d5 g7d4 d5d4 c2d4 c1c8 f8g7 c8f8 d4f3
Found mate #-4 (better) for FEN "q4rbr/2b3N1/ppR2p1p/Nn2kp1B/4p2n/PpPQR2P/1P4P1/2B3K1 b - -".
PV: a8e8 e3e4 f5e4 d3g3 e5d5 c3c4 d5d4 a5b3
Found mate #-5 (better) for FEN "8/3p4/3Pp3/N7/1p2P3/3p1pB1/1ppP1K2/brrk4 b - -".
PV: e6e5 g3e5 b4b3 e5g7 d1d2 a5c4 d2d1 g7e5 d3d2 c4e3
Found mate #-4 (better) for FEN "3r2k1/5pp1/pN2pb2/Q7/1R6/P2q4/5PPP/2r2RK1 w - -".
PV: h2h3 d3f1 g1h2 d8d3 f2f3 d3f3 g2f3 f1f2
Found mate #-5 (better) for FEN "5rk1/pQp3pp/4b3/4p1N1/3P4/6P1/PP2q2P/3R2KR w - -".
PV: g5f3 e6h3 b7b3 g8h8 b3c2 e2f3 d4e5 f3e3 c2f2 e3f2
Found mate #-6 (better) for FEN "r6k/1p2RQ1p/3p4/p1q3r1/8/1P4N1/P1b3PP/4R2K b - -".
PV: c5b5 g3h5 a8g8 f7f6 g5g7 e7g7 b5f1 e1f1 c2b3 g7g8 h8g8 f6g7
Found mate #-6 (better) for FEN "7r/1q3pRp/1n2b3/r2p4/1ppK4/2p5/1bR3B1/7k b - -".
PV: h1g1 g2f3
--nodes 1000000 done, output saved to ./master_matedtrack_threads1_nodes1e6.log
Found mate #-5 (better) for FEN "6R1/2p4K/8/8/7k/3r4/8/6R1 b - -".
PV: d3e3 g8g6 e3e7 h7h6 e7e3 g1g5 e3e5 g5e5 h4h3 e5h5
```