### PR TITLE
Wrap engine to avoid upperbound/lowerbound output

### DIFF
--- a/engine_wrap.sh
+++ b/engine_wrap.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+eval "$@" | grep --line-buffered -v bound

--- a/matecheck.py
+++ b/matecheck.py
@@ -43,7 +43,7 @@ class Analyser:
 
     def analyze_fens(self, fens):
         result_fens = []
-        engine = chess.engine.SimpleEngine.popen_uci(self.engine)
+        engine = chess.engine.SimpleEngine.popen_uci(["/bin/sh","./engine_wrap.sh", self.engine])
         if self.hash is not None:
             engine.configure({"Hash": self.hash})
         if self.threads is not None:


### PR DESCRIPTION
outputs such as `score mate 6 upperbound` confuse the matechecking script. There seems no easy way to filter this from python-chess, so wrap the engine instead.

This yields (for current SF master):

master:
Using ./stockfish.master on matetrack.epd with --nodes 1000000
Total fens:    6556
Found mates:   3434
Best mates:    2389
Complete PVs:  3432/3434 (99.9%)
Complete best PVs:  2388/2389 (100.0%)

wrapper:
Using ./stockfish.master on matetrack.epd with --nodes 1000000
Total fens:    6556
Found mates:   3432
Best mates:    2388
Complete PVs:  3432/3432 (100.0%)
Complete best PVs:  2388/2388 (100.0%)

nicely showing we have complete PVs all the time, if the iteration completes.