### PR TITLE
outsource the PV analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ options:
   --concurrency CONCURRENCY
                         total number of threads script may use, default: cpu_count() (default: 8)
   --epdFile EPDFILE     file containing the positions and their mate scores (default: matetrack.epd)
-  --showAllIssues       show all UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
+  --showAllIssues       show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
 ```
 
 Sample output:
@@ -47,7 +47,7 @@ Found mates:   524
 Best mates:    355
 
 Parsing the engine's full UCI output, the following issues were detected:
-Bad PVs:       773   (from 351 FENs)
+Bad PVs:       600   (from 351 FENs)
 ```
 
 Note that the mate counts are out of the total number of FENs, while the

--- a/matecheck.py
+++ b/matecheck.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--showAllIssues",
         action="store_true",
-        help="show all UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue",
+        help="show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue",
     )
     args = parser.parse_args()
     if args.nodes is None and args.depth is None and args.time is None:


### PR DESCRIPTION
This moves the (expensive) PV status checks from the post-processing to the concurrent analyses.

Also count each unique (mate, PV) pair at most once for the issues.

Master:
```
Using ./stockfish on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20240608-e271059e
Total FENs:    6556
Found mates:   3419
Best mates:    2518

Parsing the engine's full UCI output, the following issues were detected:
Bad PVs:       3   (from 2 FENs)
```

Patch:
```
Using ./stockfish on matetrack.epd with --nodes 1000000
Engine ID:     Stockfish dev-20240608-e271059e
Total FENs:    6556
Found mates:   3419
Best mates:    2518

Parsing the engine's full UCI output, the following issues were detected:
Bad PVs:       2   (from 2 FENs)
```