### PR TITLE
shuffle fens

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -1,4 +1,4 @@
-import argparse, re, concurrent.futures, chess, chess.engine
+import argparse, random, re, concurrent.futures, chess, chess.engine
 from time import time
 from multiprocessing import freeze_support, cpu_count
 from tqdm import tqdm
@@ -189,6 +189,7 @@ if __name__ == "__main__":
 
     maxbm = max([abs(bm) for bm in fens.values()]) if fens else 0
     fens = list(fens.items())
+    random.shuffle(fens)  # try to balance the analysis time across chunks
 
     print(f"Loaded {len(fens)} FENs, with max(abs(bm)) = {maxbm}.")
 

--- a/matecheck.py
+++ b/matecheck.py
@@ -189,6 +189,7 @@ if __name__ == "__main__":
 
     maxbm = max([abs(bm) for bm in fens.values()]) if fens else 0
     fens = list(fens.items())
+    random.seed(42)
     random.shuffle(fens)  # try to balance the analysis time across chunks
 
     print(f"Loaded {len(fens)} FENs, with max(abs(bm)) = {maxbm}.")


### PR DESCRIPTION
Idea is to get more homogenized chunks, so that last chunks do not use a significantly larger amount of CPU time than initial ones.

First checks do not seem to show a huge difference, but I guess it cannot hurt. Not sure if we should include, say, `random.seed(42)` to make `matecheck.py` itself reproducable?

Patch:
```
> time python matecheck.py --epdFile mates2000.epd --mate 0 --concurrency 32 --engine ./sf 
Loaded 2000 FENs, with max(abs(bm)) = 27.

Matetrack started for ./sf on mates2000.epd with --mate 0 ...
100%|âââââââââââââââââââââââââââââââââââââââââ| 134/134 [11:42<00:00,  5.24s/it]


Using ./sf on mates2000.epd with --mate 0
Engine ID:     Stockfish dev-20240615-2046c92a
Total FENs:    2000
Found mates:   2000
Best mates:    2000

Best mate statistics:
abs(bm) = 1 - mates: 6, nodes (min avg max): 77 211 589, depth (min avg max): 1 4 7
abs(bm) = 2 - mates: 12, nodes (min avg max): 21 7827 67580, depth (min avg max): 5 14 41
abs(bm) = 3 - mates: 32, nodes (min avg max): 192 48012 857343, depth (min avg max): 8 19 29
abs(bm) = 4 - mates: 69, nodes (min avg max): 603 443765 8251188, depth (min avg max): 6 22 51
abs(bm) = 5 - mates: 126, nodes (min avg max): 643 466338 10092607, depth (min avg max): 8 25 49
abs(bm) = 6 - mates: 413, nodes (min avg max): 183 849371 50567379, depth (min avg max): 7 26 78
abs(bm) = 7 - mates: 484, nodes (min avg max): 232 5209812 1076452597, depth (min avg max): 6 27 103
abs(bm) = 8 - mates: 248, nodes (min avg max): 675 914617 59890563, depth (min avg max): 9 29 71
abs(bm) = 9 - mates: 187, nodes (min avg max): 287 11059745 1093852308, depth (min avg max): 1 28 85
abs(bm) = 10 - mates: 113, nodes (min avg max): 1485 21497501 2187048638, depth (min avg max): 1 28 75
abs(bm) = 11 - mates: 82, nodes (min avg max): 1642 8079758 430431289, depth (min avg max): 13 30 80
abs(bm) = 12 - mates: 65, nodes (min avg max): 1605 448835 8857191, depth (min avg max): 13 28 50
abs(bm) = 13 - mates: 41, nodes (min avg max): 6947 1351429 36076971, depth (min avg max): 14 29 59
abs(bm) = 14 - mates: 41, nodes (min avg max): 11941 1092196 16801359, depth (min avg max): 13 31 52
abs(bm) = 15 - mates: 25, nodes (min avg max): 9796 352060 2244850, depth (min avg max): 12 30 102
abs(bm) = 16 - mates: 11, nodes (min avg max): 55681 257918 874845, depth (min avg max): 22 33 41
abs(bm) = 17 - mates: 14, nodes (min avg max): 23177 978314 5556968, depth (min avg max): 24 36 59
abs(bm) = 18 - mates: 8, nodes (min avg max): 11957 393802 925723, depth (min avg max): 19 35 60
abs(bm) = 19 - mates: 5, nodes (min avg max): 12344 272390 1000168, depth (min avg max): 20 40 60
abs(bm) = 20 - mates: 9, nodes (min avg max): 11287 393234 1690144, depth (min avg max): 19 38 62
abs(bm) = 21 - mates: 4, nodes (min avg max): 11906 725463 1672773, depth (min avg max): 22 38 49
abs(bm) = 22 - mates: 2, nodes (min avg max): 29276 50419 71562, depth (min avg max): 19 40 62
abs(bm) = 24 - mates: 1, nodes (min avg max): 412305 412305 412305, depth (min avg max): 49 49 49
abs(bm) = 25 - mates: 1, nodes (min avg max): 205682 205682 205682, depth (min avg max): 47 47 47
abs(bm) = 27 - mates: 1, nodes (min avg max): 357995 357995 357995, depth (min avg max): 43 43 43
4395.725u 77.840s 11:42.89 636.4%       0+0k 3280+0io 123pf+0w
```

Master
```
> time python matecheck.py --epdFile mates2000.epd --mate 0 --concurrency 32 --engine ./sf
Loaded 2000 FENs, with max(abs(bm)) = 27.

Matetrack started for ./sf on mates2000.epd with --mate 0 ...
100%|âââââââââââââââââââââââââââââââââââââââââ| 134/134 [11:58<00:00,  5.36s/it]


Using ./sf on mates2000.epd with --mate 0
Engine ID:     Stockfish dev-20240615-2046c92a
Total FENs:    2000
Found mates:   2000
Best mates:    2000

Best mate statistics:
abs(bm) = 1 - mates: 6, nodes (min avg max): 77 211 589, depth (min avg max): 1 4 7
abs(bm) = 2 - mates: 12, nodes (min avg max): 21 7827 67580, depth (min avg max): 5 14 41
abs(bm) = 3 - mates: 32, nodes (min avg max): 192 48012 857343, depth (min avg max): 8 19 29
abs(bm) = 4 - mates: 69, nodes (min avg max): 603 443765 8251188, depth (min avg max): 6 22 51
abs(bm) = 5 - mates: 126, nodes (min avg max): 643 466338 10092607, depth (min avg max): 8 25 49
abs(bm) = 6 - mates: 413, nodes (min avg max): 183 849371 50567379, depth (min avg max): 7 26 78
abs(bm) = 7 - mates: 484, nodes (min avg max): 232 5209812 1076452597, depth (min avg max): 6 27 103
abs(bm) = 8 - mates: 248, nodes (min avg max): 675 914617 59890563, depth (min avg max): 9 29 71
abs(bm) = 9 - mates: 187, nodes (min avg max): 287 11059745 1093852308, depth (min avg max): 1 28 85
abs(bm) = 10 - mates: 113, nodes (min avg max): 1485 21497501 2187048638, depth (min avg max): 1 28 75
abs(bm) = 11 - mates: 82, nodes (min avg max): 1642 8079758 430431289, depth (min avg max): 13 30 80
abs(bm) = 12 - mates: 65, nodes (min avg max): 1605 448835 8857191, depth (min avg max): 13 28 50
abs(bm) = 13 - mates: 41, nodes (min avg max): 6947 1351429 36076971, depth (min avg max): 14 29 59
abs(bm) = 14 - mates: 41, nodes (min avg max): 11941 1092196 16801359, depth (min avg max): 13 31 52
abs(bm) = 15 - mates: 25, nodes (min avg max): 9796 352060 2244850, depth (min avg max): 12 30 102
abs(bm) = 16 - mates: 11, nodes (min avg max): 55681 257918 874845, depth (min avg max): 22 33 41
abs(bm) = 17 - mates: 14, nodes (min avg max): 23177 978314 5556968, depth (min avg max): 24 36 59
abs(bm) = 18 - mates: 8, nodes (min avg max): 11957 393802 925723, depth (min avg max): 19 35 60
abs(bm) = 19 - mates: 5, nodes (min avg max): 12344 272390 1000168, depth (min avg max): 20 40 60
abs(bm) = 20 - mates: 9, nodes (min avg max): 11287 393234 1690144, depth (min avg max): 19 38 62
abs(bm) = 21 - mates: 4, nodes (min avg max): 11906 725463 1672773, depth (min avg max): 22 38 49
abs(bm) = 22 - mates: 2, nodes (min avg max): 29276 50419 71562, depth (min avg max): 19 40 62
abs(bm) = 24 - mates: 1, nodes (min avg max): 412305 412305 412305, depth (min avg max): 49 49 49
abs(bm) = 25 - mates: 1, nodes (min avg max): 205682 205682 205682, depth (min avg max): 47 47 47
abs(bm) = 27 - mates: 1, nodes (min avg max): 357995 357995 357995, depth (min avg max): 43 43 43
4247.021u 66.025s 11:58.56 600.2%       0+0k 1760+0io 172pf+0w
```