### PR TITLE
check TB win PV correctness (take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ options:
   --hash HASH           hash table size in MB (default: None)
   --threads THREADS     number of threads per position (values > 1 may lead to non-deterministic results) (default: None)
   --syzygyPath SYZYGYPATH
-                        path to syzygy EGTBs (default: None)
+                        path(s) to syzygy EGTBs, with ':' as separator (default: None)
   --minTBscore MINTBSCORE
                         lowest cp score for a TB win (default: 19754)
   --concurrency CONCURRENCY

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--showAllStats]
+usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--showAllStats]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -33,6 +33,8 @@ options:
   --threads THREADS     number of threads per position (values > 1 may lead to non-deterministic results) (default: None)
   --syzygyPath SYZYGYPATH
                         path to syzygy EGTBs (default: None)
+  --minTBscore MINTBSCORE
+                        lowest cp score for a TB win (default: 19754)
   --concurrency CONCURRENCY
                         total number of threads script may use, default: cpu_count() (default: 8)
   --epdFile EPDFILE [EPDFILE ...]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--showAllStats]
+usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -40,6 +40,7 @@ options:
   --epdFile EPDFILE [EPDFILE ...]
                         file(s) containing the positions and their mate scores (default: ['matetrack.epd'])
   --showAllIssues       show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
+  --shortTBPVonly       for TB win scores, only consider short PVs an issue (default: False)
   --showAllStats        show nodes and depth statistics for best mates found (always True if --mate is supplied) (default: False)
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ options:
   --hash HASH           hash table size in MB (default: None)
   --threads THREADS     number of threads per position (values > 1 may lead to non-deterministic results) (default: None)
   --syzygyPath SYZYGYPATH
-                        path(s) to syzygy EGTBs, with ':' as separator (default: None)
+                        path(s) to syzygy EGTBs, with ':'/';' as separator on Linux/Windows (default: None)
   --minTBscore MINTBSCORE
                         lowest cp score for a TB win (default: 19754)
   --concurrency CONCURRENCY

--- a/matecheck.py
+++ b/matecheck.py
@@ -6,7 +6,9 @@ from tqdm import tqdm
 
 class TB:
     def __init__(self, path):
-        self.tb = chess.syzygy.open_tablebase(path)
+        self.tb = chess.syzygy.Tablebase()
+        for d in path.split(":"):
+            self.tb.add_directory(d)
 
     def probe(self, board):
         if (
@@ -171,7 +173,9 @@ if __name__ == "__main__":
         type=int,
         help="number of threads per position (values > 1 may lead to non-deterministic results)",
     )
-    parser.add_argument("--syzygyPath", help="path to syzygy EGTBs")
+    parser.add_argument(
+        "--syzygyPath", help="path(s) to syzygy EGTBs, with ':' as separator"
+    )
     parser.add_argument(
         "--minTBscore",
         type=int,
@@ -297,6 +301,10 @@ if __name__ == "__main__":
     print("")
 
     tb = TB(args.syzygyPath) if args.syzygyPath is not None else None
+    if tb is not None:
+        c = sum(1 for (_, score, _) in pvstatus if score is not None)
+        if c:
+            print(f"\nChecking {c} TB win PVs. This may take some time...")
     mates = bestmates = tbwins = 0
     issue = {
         "Better mates": [0, 0],

--- a/matecheck.py
+++ b/matecheck.py
@@ -302,9 +302,12 @@ if __name__ == "__main__":
 
     tb = TB(args.syzygyPath) if args.syzygyPath is not None else None
     if tb is not None:
-        c = sum(1 for (_, score, _) in pvstatus if score is not None)
+        c = 0
+        for _, _, pvstatus, _, _ in res:
+            c += sum(1 for (_, score, _) in pvstatus if score is not None)
         if c:
             print(f"\nChecking {c} TB win PVs. This may take some time...")
+
     mates = bestmates = tbwins = 0
     issue = {
         "Better mates": [0, 0],

--- a/matecheck.py
+++ b/matecheck.py
@@ -1,7 +1,20 @@
-import argparse, random, re, concurrent.futures, chess, chess.engine
+import argparse, random, re, concurrent.futures, chess, chess.engine, chess.syzygy
 from time import time
 from multiprocessing import freeze_support, cpu_count
 from tqdm import tqdm
+
+
+class TB:
+    def __init__(self, path):
+        self.tb = chess.syzygy.open_tablebase(path)
+
+    def probe(self, board):
+        if (
+            board.castling_rights
+            or chess.popcount(board.occupied) > chess.syzygy.TBPIECES
+        ):
+            return None
+        return self.tb.get_wdl(board)
 
 
 def chunks(lst, n):
@@ -10,28 +23,53 @@ def chunks(lst, n):
         yield lst[i : i + n]
 
 
-def pv_status(fen, mate, pv):
+def pv_status(fen, mate, score, pv, tb=None):
     # check if the given pv (list of uci moves) leads to checkmate #mate
-    losing_side = 1 if mate > 0 else 0
+    # if mate is None, check if pv leads to claimed TB win/loss
+    losing_side = 1 if (mate and mate > 0) or (score and score > 0) else 0
     try:
         board = chess.Board(fen)
         for ply, move in enumerate(pv):
             if ply % 2 == losing_side and board.can_claim_draw():
                 return "draw"
+            # if EGTB is available, probe it to check PV correctness
+            if tb is not None:
+                wdl = tb.probe(board)
+                if wdl is not None:
+                    if abs(wdl) != 2:
+                        return "draw"
+                    if ply % 2 == losing_side and wdl != -2:
+                        return "wrong"
+                    if ply % 2 != losing_side and wdl != 2:
+                        return "wrong"
             uci = chess.Move.from_uci(move)
             if not uci in board.legal_moves:
                 raise Exception(f"illegal move {move} at position {board.epd()}")
             board.push(uci)
     except Exception as ex:
         return f'error "{ex}"'
-    plies_to_checkmate = 2 * mate - 1 if mate > 0 else -2 * mate
-    if len(pv) < plies_to_checkmate:
+
+    if mate:
+        plies_to_checkmate = 2 * mate - 1 if mate > 0 else -2 * mate
+        if len(pv) < plies_to_checkmate:
+            return "short"
+        if len(pv) > plies_to_checkmate:
+            return "long"
+        if board.is_checkmate():
+            return "ok"
+        return "wrong"
+
+    # now check if the leaf node is in EGTB, with the correct result
+    wdl = tb.probe(board)
+    if wdl is None:
         return "short"
-    if len(pv) > plies_to_checkmate:
-        return "long"
-    if board.is_checkmate():
-        return "ok"
-    return "wrong"
+    if abs(wdl) != 2:
+        return "draw"
+    if (ply + 1) % 2 == losing_side and wdl != -2:
+        return "wrong"
+    if (ply + 1) % 2 != losing_side and wdl != 2:
+        return "wrong"
+    return "ok"
 
 
 class Analyser:
@@ -49,6 +87,7 @@ class Analyser:
         self.hash = args.hash
         self.threads = args.threads
         self.syzygyPath = args.syzygyPath
+        self.minTBscore = args.minTBscore
 
     def analyze_fens(self, fens):
         result_fens = []
@@ -62,6 +101,8 @@ class Analyser:
         for fen, bm in fens:
             board = chess.Board(fen)
             pvstatus = {}  #  stores (status, final_line)
+            m, score, pvstr = None, None, ""
+            nodes = depth = 0
             if self.mate is not None and self.mate == 0:
                 limit = chess.engine.Limit(
                     nodes=self.nodes, depth=self.depth, time=self.time, mate=abs(bm)
@@ -73,19 +114,27 @@ class Analyser:
                     if "score" in info and not (
                         "upperbound" in info or "lowerbound" in info
                     ):
-                        m = info["score"].pov(board.turn).mate()
-                        if m is None:
+                        score = info["score"].pov(board.turn)
+                        m = score.mate()
+                        score = score.score()
+                        if m is None and (
+                            self.syzygyPath is None
+                            or score is None
+                            or abs(score) < self.minTBscore
+                        ):
                             continue
                         pv = [m.uci() for m in info["pv"]] if "pv" in info else []
                         pvstr = " ".join(pv)
-                        if (m, pvstr) not in pvstatus:
-                            pvstatus[m, pvstr] = pv_status(fen, m, pv), False
+                        if (m, score, pvstr) not in pvstatus:
+                            pvstatus[m, score, pvstr] = (
+                                (pv_status(fen, m, score, pv), False)
+                                if m
+                                else ("None", False)
+                            )
                         nodes = info.get("nodes", 0)
                         depth = info.get("depth", 0)
-            if m:  # if final info line has a mate score, mark it as such
-                pvstatus[m, pvstr] = pvstatus[m, pvstr][0], True
-            else:
-                nodes = depth = 0
+            if (m, score, pvstr) in pvstatus:  # mark final info line
+                pvstatus[m, score, pvstr] = pvstatus[m, score, pvstr][0], True
             result_fens.append((fen, bm, pvstatus, nodes, depth))
 
         engine.quit()
@@ -125,6 +174,12 @@ if __name__ == "__main__":
         help="number of threads per position (values > 1 may lead to non-deterministic results)",
     )
     parser.add_argument("--syzygyPath", help="path to syzygy EGTBs")
+    parser.add_argument(
+        "--minTBscore",
+        type=int,
+        help="lowest cp score for a TB win",
+        default=20000 - 246,
+    )
     parser.add_argument(
         "--concurrency",
         type=int,
@@ -238,13 +293,20 @@ if __name__ == "__main__":
 
     print("")
 
-    mates = bestmates = 0
-    issue = {"Better mates": [0, 0], "Wrong mates": [0, 0], "Bad PVs": [0, 0]}
+    mates = bestmates = tbwins = 0
+    issue = {
+        "Better mates": [0, 0],
+        "Wrong mates": [0, 0],
+        "Bad PVs": [0, 0],
+        "Wrong TB score": [0, 0],
+    }
     bestnodes = [[] for _ in range(maxbm + 1)]
     bestdepth = [[] for _ in range(maxbm + 1)]
     for fen, bestmate, pvstatus, nodes, depth in res:
         found_better = found_wrong = found_badpv = False
-        for (mate, pv), (status, last_line) in pvstatus.items():
+        for (mate, score, pv), (status, last_line) in pvstatus.items():
+            if mate is None:
+                continue
             if mate * bestmate > 0:
                 if last_line:  #  for mate counts use last valid UCI info output
                     mates += 1
@@ -286,6 +348,38 @@ if __name__ == "__main__":
     print("Total FENs:   ", numfen)
     print("Found mates:  ", mates)
     print("Best mates:   ", bestmates)
+
+    if args.syzygyPath is not None:
+        tb = TB(args.syzygyPath)
+        for fen, bestmate, pvstatus, nodes, depth in res:
+            found_badpv = found_wrong_tb = False
+            for (mate, score, pv), (status, last_line) in pvstatus.items():
+                if mate:
+                    continue
+                if score * bestmate > 0:
+                    if last_line:
+                        tbwins += 1
+                    status = pv_status(fen, mate, score, pv.split(), tb)
+                    if status != "ok":
+                        issue["Bad PVs"][0] += 1
+                        if not found_badpv or args.showAllIssues:
+                            issue["Bad PVs"][1] += int(not found_badpv)
+                            found_badpv = True
+                            print(
+                                f'Found TB score {score} with PV status "{status}" for FEN "{fen}" with bm #{bestmate}.'
+                            )
+                            print("PV:", pv)
+                else:
+                    issue["Wrong TB score"][0] += 1
+                    if not found_wrong_tb or args.showAllIssues:
+                        issue["Wrong TB score"][1] += int(not found_wrong_tb)
+                        found_wrong_tb = True
+                        print(
+                            f'Found TB score {score} (wrong sign) for FEN "{fen}" with bm #{bestmate}.'
+                        )
+                        print("PV:", pv)
+    if tbwins:
+        print("Found TB wins:", tbwins)
 
     if args.showAllStats or args.mate is not None:
         print("\nBest mate statistics:")

--- a/matecheck.py
+++ b/matecheck.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
         "--minTBscore",
         type=int,
         help="lowest cp score for a TB win",
-        default=20000 - 246,
+        default=20000 - 246,  # for SF this is TB_CP - MAX_PLY
     )
     parser.add_argument(
         "--concurrency",

--- a/matecheck.py
+++ b/matecheck.py
@@ -1,4 +1,4 @@
-import argparse, random, re, concurrent.futures, chess, chess.engine, chess.syzygy
+import argparse, random, re, sys, concurrent.futures, chess, chess.engine, chess.syzygy
 from time import time
 from multiprocessing import freeze_support, cpu_count
 from tqdm import tqdm
@@ -7,7 +7,8 @@ from tqdm import tqdm
 class TB:
     def __init__(self, path):
         self.tb = chess.syzygy.Tablebase()
-        for d in path.split(":"):
+        sep = ";" if sys.platform.startswith("win") else ":"
+        for d in path.split(sep):
             self.tb.add_directory(d)
 
     def probe(self, board):
@@ -174,7 +175,7 @@ if __name__ == "__main__":
         help="number of threads per position (values > 1 may lead to non-deterministic results)",
     )
     parser.add_argument(
-        "--syzygyPath", help="path(s) to syzygy EGTBs, with ':' as separator"
+        "--syzygyPath", help="path(s) to syzygy EGTBs, with ':'/';' as separator on Linux/Windows"
     )
     parser.add_argument(
         "--minTBscore",

--- a/matecheck.py
+++ b/matecheck.py
@@ -127,10 +127,8 @@ class Analyser:
                         pvstr = " ".join(pv)
                         if (m, score, pvstr) not in pvstatus:
                             pvstatus[m, score, pvstr] = (
-                                (pv_status(fen, m, score, pv), False)
-                                if m
-                                else ("None", False)
-                            )
+                                pv_status(fen, m, score, pv) if m else "None"
+                            ), False
                         nodes = info.get("nodes", 0)
                         depth = info.get("depth", 0)
             if (m, score, pvstr) in pvstatus:  # mark final info line


### PR DESCRIPTION
This is the follow-up for https://github.com/vondele/matetrack/pull/95

I did some quick testing, but it probably needs a careful check by a second pair of eyes.

The example below shows that sf-dev has many PVs that lose the win once in TB. This can be seen by status `"draw"`, whereas `"short"` would indicate the PV does not reach TB (which I believe currently is the main concern for @vondele ).

```
> python matecheck.py --engine ./stockfish --epdFile mates2000.epd --syzygyPath /disk2/syzygy/ --nodes 10000
Loaded 2000 FENs, with max(abs(bm)) = 27.

Matetrack started for ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath /disk2/syzygy/ ...
100%|#########################################| 100/100 [00:20<00:00,  4.98it/s]


Using ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath /disk2/syzygy/
Engine ID:     Stockfish dev-20240615-2046c92a
Total FENs:    2000
Found mates:   391
Best mates:    328
Found TB score -20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/1Bp5/1b6 b - -" with bm #-6.
PV: a3a2 b6d5 c2c1q b2c1
Found TB score 20000 with PV status "draw" for FEN "7k/8/5rRK/5P2/8/1B6/8/8 w - -" with bm #8.
PV: h6g5 f6g6 g5g6
Found TB score 20000 with PV status "draw" for FEN "8/8/8/5K2/7k/7p/7N/7N w - -" with bm #9.
PV: h2f3 h4h5 h1g3 h5h6
Found TB score 20000 with PV status "draw" for FEN "8/1B6/5N2/8/b7/8/p7/k1K5 w - -" with bm #7.
PV: f6e4 a4b3 b7a8 b3c2 c1c2
Found TB score -20000 with PV status "draw" for FEN "rr5k/RR6/7K/8/8/8/8/8 b - -" with bm #-6.
PV: h8g8 b7b8 a8b8
Found TB score -20000 with PV status "draw" for FEN "1b6/2p5/8/2K5/k7/8/1PB5/8 b - -" with bm #-7.
PV: a4a5 b2b4 a5a6 c2d3 a6b7
Found TB score 20000 with PV status "draw" for FEN "8/8/8/7K/6Np/7p/7N/7k w - -" with bm #10.
PV: h5g5 h1g1 g5f5 g1h1 f5f4 h1g2 f4e4 g2g3 e4e5 g3g2 e5f4 g2g1 f4f3 g1h1 f3f2
Found TB score 19995 with PV status "draw" for FEN "8/8/4pN2/6p1/5p2/7p/8/5K1k w - -" with bm #9.
PV: f6g4 f4f3 f1f2 e6e5 g4e5 h1h2 e5f3 h2h1
Found TB score -20000 with PV status "wrong" for FEN "4N3/8/8/3p1p2/8/8/p7/k1K5 b - -" with bm #-6.
PV: f5f4 e8g7 f4f3 g7f5
Found TB score 20000 with PV status "draw" for FEN "8/7n/7P/8/6nK/5k2/8/8 b - -" with bm #10.
PV: f3f4 h4h3 h7g5 h3g2
Found TB score -19992 with PV status "draw" for FEN "8/8/8/8/4N3/p1K1N3/p7/rk6 b - -" with bm #-10.
PV: b1c1 e4c5 c1b1 c3d2 b1b2 e3c4 b2b1 c4a3 b1b2 a3c4 b2b1 d2c3 b1c1 c5d3 c1d1
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/1N5B/p7/4r3/k1K5 b - -" with bm #-8.
PV: e2e6 b4c2 a1a2
Found TB score -19986 with PV status "wrong" for FEN "4R1B1/6pk/8/6K1/8/1p6/p1bp3p/8 b - -" with bm #-9.
PV: h7h8 g8b3 h8h7 b3g8 h7h8 g8a2 h8h7 a2g8 h7h8 g8b3 h8h7 b3c2 g7g6 c2g6 h7g7 e8e7 g7g8 g6h7 g8f8
Found TB score -19992 with PV status "draw" for FEN "8/8/2N5/7K/4N3/6bk/8/5B1n b - -" with bm #-8.
PV: h3h2 c6d4 h2g1 f1h3 g1h2 h5g4 h1f2 e4f2 h2g1 g4g3
Found TB score -19996 with PV status "draw" for FEN "2N5/5K2/4p2k/8/2p3PP/8/8/8 b - -" with bm #-7.
PV: h6h7 c8e7 h7h8 f7e6 h8h7 g4g5 h7g7 g5g6 g7h6 e7g8 h6g6
Found TB score -20000 with PV status "draw" for FEN "1b6/k1p5/2K2N2/8/8/8/8/5B2 b - -" with bm #-8.
PV: a7a8 f6d7 b8a7 c6c7
Found TB score -20000 with PV status "draw" for FEN "8/p7/8/8/P7/3N4/5K1p/7k b - -" with bm #-6.
PV: a7a5 d3f4
Found TB score -20000 with PV status "draw" for FEN "7k/8/4B1K1/8/4R3/1r6/8/8 b - -" with bm #-6.
PV: b3b4 e6g4 b4e4
Found TB score 19999 with PV status "draw" for FEN "5K1k/5PN1/7q/4Q3/8/6p1/8/8 w - -" with bm #7.
PV: e5g3 h6h7 g3h3 h7h3
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/2Q5/1qN5/k7/2K5 b - -" with bm #-7.
PV: a2a3 c3b1 b3b1 c1b1
Found TB score -20000 with PV status "draw" for FEN "8/8/N7/2B5/8/7p/5K1P/7k b - -" with bm #-7.
PV: h1h2 a6b4
Found TB score -19996 with PV status "draw" for FEN "8/8/8/2Kp4/k1p5/1rp5/8/Q7 b - -" with bm #-14.
PV: b3a3 a1d1 c3c2 d1c2 a3b3 c5d5 a4b4 c2c4 b4a3 c4c1 a3b4 c1c5 b4a4 d5c4
Found TB score -20000 with PV status "draw" for FEN "Q7/8/8/8/8/8/6rp/4K2k b - -" with bm #-11.
PV: h1g1 a8a7 g1h1 a7a6 g2g3 e1f2 g3g2 f2f3
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/6NK/7p/7N/7k b - -" with bm #-9.
PV: h1g1 h4h3
Found TB score 19997 with PV status "draw" for FEN "8/8/8/3K4/p7/pk1B4/p7/B7 w - -" with bm #11.
PV: d3c4 b3c2 c4a2 c2d3 a1g7 d3d2 g7f8 d2c1 d5c4
Found TB score 19993 with PV status "wrong" for FEN "k7/q2N4/3K4/8/8/6Q1/2p5/n7 w - -" with bm #13.
PV: g3g2 a7b7 g2g8 a8a7 g8g1 a7a6 g1a1 a6b5 a1g1
Found TB score 19991 with PV status "draw" for FEN "6b1/2B2p2/5K1k/8/6P1/3p4/8/8 w - -" with bm #9.
PV: c7f4 h6h7 g4g5 h7h8 f4e5 h8h7 e5c3 d3d2 c3d2 h7h8 d2b4 h8h7 b4c3
Found TB score -20000 with PV status "draw" for FEN "8/1p6/8/2P5/8/8/p2K4/Bk6 b - -" with bm #-9.
PV: b1a1 d2c1
Found TB score 20000 with PV status "draw" for FEN "7k/8/4K3/5N2/3N4/4p3/8/8 w - -" with bm #9.
PV: d4e2 h8g8 f5e7 g8g7 e2f4
Found TB score -19996 with PV status "draw" for FEN "8/8/8/8/2b1p3/3NB1K1/8/3B3k b - -" with bm #-6.
PV: c4a2 d3f2 h1g1 f2e4 g1f1 e4c3 f1e1 e3f2 e1f1 c3a2
Found TB score 20000 with PV status "draw" for FEN "8/8/6p1/4N3/6N1/8/5K2/7k w - -" with bm #7.
PV: e5f3 g6g5 g4e3
Found TB score -19996 with PV status "draw" for FEN "k7/2P5/b3B3/K5Qq/8/8/8/8 b - -" with bm #-6.
PV: h5e8 g5d8 a8a7 d8e8 a6c8 e8c8
Found TB score 20000 with PV status "draw" for FEN "7Q/8/8/8/8/8/6rp/4K2k w - -" with bm #12.
PV: h8a8 h1g1 a8a7 g1h1 a7f7 g2g1 e1f2 g1g2 f2e3
Found TB score -19988 with PV status "draw" for FEN "n6k/4r3/6K1/5p2/8/7Q/8/b7 b - -" with bm #-11.
PV: h8g8 h3b3 g8f8 b3b8 e7e8 b8d6 e8e7 d6d8 e7e8 d8d7 e8e7 d7f5 f8e8 f5b5 e7d7
Found TB score 20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/2p5/Bb6 w - -" with bm #7.
PV: a1b2 a3a2 b6a4
Found TB score -19992 with PV status "draw" for FEN "Q7/8/2Np4/1p6/1pp5/6q1/8/k1K5 b - -" with bm #-10.
PV: g3a3 a8a3 b4a3 c6b4 c4c3 c1c2 d6d5 b4d5 a1a2 d5c3 a2a1
Found TB score -19996 with PV status "draw" for FEN "8/3p4/8/4B3/8/8/r4p2/3R1K1k b - -" with bm #-8.
PV: a2c2 d1d3 c2c1 f1f2 c1c2 f2f3 c2g2 d3d1 g2g1 d1d7 g1f1 f3g4
Found TB score 19993 with PV status "wrong" for FEN "8/8/K7/8/1p6/1p6/1B5p/5B1k w - -" with bm #12.
PV: b2d4 b3b2 f1d3 h1g2 d3e4 g2g3 d4b2 g3f4 a6b5 f4e4 b5b4 h2h1q
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/4R3/8/p1K1n3/k7 b - -" with bm #-8.
PV: e2d4 c2c3 d4f3 e4b4 f3e1 b4f4
Found TB score -20000 with PV status "draw" for FEN "8/8/6p1/8/2N3N1/8/5K2/7k b - -" with bm #-6.
PV: g6g5 c4d2
Found TB score -20000 with PV status "draw" for FEN "8/2p5/8/2p5/8/7P/p7/k1K5 b - -" with bm #-7.
PV: c5c4 c1c2 c4c3 c2c1 c7c6
Found TB score -20000 with PV status "draw" for FEN "7K/8/8/1p6/8/3N4/2N5/kB6 b - -" with bm #-11.
PV: a1b1 c2a3 b1a2
Found TB score -20000 with PV status "draw" for FEN "8/8/2Q5/8/8/7p/8/q2N1K1k b - -" with bm #-11.
PV: h1h2 c6d6 h2h1 d6d5 h1h2 d5d2 h2g3
Found TB score -20000 with PV status "draw" for FEN "1k6/8/3N4/1N6/6pK/8/8/7B b - -" with bm #-7.
PV: g4g3 h4g3
Found TB score -19998 with PV status "draw" for FEN "8/8/2p5/1kP5/1N6/1P1N4/1K6/8 b - -" with bm #-9.
PV: b5a5 b4c6 a5b5 c6d4 b5a5 b3b4 a5a4 c5c6
Found TB score -19998 with PV status "draw" for FEN "5K1k/5p1q/5B2/8/5P2/6P1/8/8 b - -" with bm #-9.
PV: h7g7 f6g7 h8h7 f8f7
Found TB score 20000 with PV status "draw" for FEN "8/8/8/8/3N2b1/3P4/5K1p/7k w - -" with bm #6.
PV: d4c6 g4h3 c6d4 h3g4 d4c2
Found TB score -20000 with PV status "draw" for FEN "8/4p3/8/8/8/1N3p1p/5K2/7k b - -" with bm #-15.
PV: e7e6 b3d2 e6e5 d2f1 e5e4 f1g3 h1h2 g3e4 h2h1
Found TB score -19996 with PV status "draw" for FEN "7k/8/5N1K/4B3/8/6pp/8/7b b - -" with bm #-8.
PV: g3g2 e5h2 g2g1r h2g1 h1a8 g1d4
Found TB score 20000 with PV status "draw" for FEN "8/3p4/8/6n1/8/8/2R4p/5K1k w - -" with bm #12.
PV: c2c1 g5e4 c1e1 d7d5 e1d1
Found TB wins: 302

Parsing the engine's full UCI output, the following issues were detected:
Bad PVs:       95   (from 50 FENs)
```

Notice also that some PVs seem to turn a win into a loss (though I have not checked these in detail yet).
```
> python matecheck.py --engine ./stockfish --epdFile mates2000.epd --syzygyPath /disk2/syzygy/ --nodes 10000 | grep status | grep -v draw
100%|#########################################| 100/100 [00:18<00:00,  5.48it/s]
Found TB score -19986 with PV status "wrong" for FEN "4R1B1/6pk/8/6K1/8/1p6/p1bp3p/8 b - -" with bm #-9.
Found TB score -20000 with PV status "wrong" for FEN "4N3/8/8/3p1p2/8/8/p7/k1K5 b - -" with bm #-6.
Found TB score 19993 with PV status "wrong" for FEN "k7/q2N4/3K4/8/8/6Q1/2p5/n7 w - -" with bm #13.
Found TB score 19993 with PV status "wrong" for FEN "8/8/K7/8/1p6/1p6/1B5p/5B1k w - -" with bm #12.
```