### PR TITLE
add option --bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats]
+usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -42,6 +42,7 @@ options:
   --showAllIssues       show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
   --shortTBPVonly       for TB win scores, only consider short PVs an issue (default: False)
   --showAllStats        show nodes and depth statistics for best mates found (always True if --mate is supplied) (default: False)
+  --bench               provide cumulative statistics for nodes searched and time used (ignoring upper/lower bound UCI info lines) (default: False)
 ```
 
 Sample output:


### PR DESCRIPTION
This PR introduces the option `--bench`. Example output:
```
> python matecheck.py --nodes 1000 --bench
Loaded 6555 FENs, with max(abs(bm)) = 126.

Matetrack started for ./stockfish on matetrack.epd with --nodes 1000 ...

Using ./stockfish on matetrack.epd with --nodes 1000
Engine ID:     Stockfish dev-20240623-cc992e5e
Total FENs:    6555
Found mates:   45
Best mates:    34

===========================
Total time (ms) : 538
Nodes searched  : 64518
Nodes/second    : 119922
```

In addition, we only print the best mate statistics if best mates were found, and provide a final line with totals there.
Example:
```
> python matecheck.py --epdFile mates2000.epd --mate 0 --nodes 100
Loaded 2000 FENs, with max(abs(bm)) = 27.

Matetrack started for ./stockfish on mates2000.epd with --nodes 100 --mate 0 ...

Using ./stockfish on mates2000.epd with --nodes 100 --mate 0
Engine ID:     Stockfish dev-20240623-cc992e5e
Total FENs:    2000
Found mates:   8
Best mates:    8

Best mate statistics:
abs(bm) = 1 - mates: 4, nodes (min avg max): 77 114 204, depth (min avg max): 1 4 7
abs(bm) = 2 - mates: 1, nodes (min avg max): 21 21 21, depth (min avg max): 6 6 6
abs(bm) = 9 - mates: 1, nodes (min avg max): 287 287 287, depth (min avg max): 1 1 1
abs(bm) = 10 - mates: 2, nodes (min avg max): 4659 11006 17354, depth (min avg max): 1 1 1
All best mates: 8, nodes (min avg max): 21 2847 17354, depth (min avg max): 1 3 7
```

Closes #98.