### PR TITLE
improve bench output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ options:
   --showAllIssues       show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
   --shortTBPVonly       for TB win scores, only consider short PVs an issue (default: False)
   --showAllStats        show nodes and depth statistics for best mates found (always True if --mate is supplied) (default: False)
-  --bench               provide cumulative statistics for nodes searched and time used (ignoring upper/lower bound UCI info lines) (default: False)
+  --bench               provide cumulative statistics for nodes searched and time used (default: False)
 ```
 
 Sample output:


### PR DESCRIPTION
This refines my previous attempt. Unfortunately, master only reports the nodes and time stats for those searches, where a mate (or TB win) is eventually found. So not very useful, I guess.

Changing this to counting nodes searched for all possible scores meant that we can now go the whole hog and report any searched nodes (including for upper/lower bounds).

Same example as in https://github.com/vondele/matetrack/pull/103 now yields:
```
> python matecheck.py --nodes 1000 --bench
Loaded 6555 FENs, with max(abs(bm)) = 126.

Matetrack started for ./stockfish on matetrack.epd with --nodes 1000 ...

Using ./stockfish on matetrack.epd with --nodes 1000
Engine ID:     Stockfish dev-20240623-cc992e5e
Total FENs:    6555
Found mates:   45
Best mates:    34

===========================
Total time (ms) : 51353
Nodes searched  : 7273911
Nodes/second    : 141645
```