### PR TITLE
Fix lastnodes...

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -112,10 +112,12 @@ class Analyser:
                 )
             else:
                 limit = self.limit
+            lastnodes = 0
+            lasttime = 0
             with engine.analysis(board, limit, game=board) as analysis:
                 for info in analysis:
-                    lastnodes = info.get("nodes", 0)
-                    lasttime = info.get("time", 0)
+                    lastnodes = info.get("nodes", lastnodes)
+                    lasttime = info.get("time", lasttime)
                     if "score" in info and not (
                         "upperbound" in info or "lowerbound" in info
                     ):


### PR DESCRIPTION
A search can end with

```
info depth 55 seldepth 27 multipv 1 score mate -13 nodes 924222 nps 107392 hashfull 30 tbhits 14708 time 8606 pv c5c4 f3e2 c4d3 e2d3 b6b5 d3e2 d4d3 e2d3 d5d4 d3e2 d4d3 e2d3 b5b4 d3e2 b4b3 e2f1 b3b2 f1g1 b2b1q g1h2 b1h1 h2h1 a6a5 h1h2 a5a4 g2g3
info depth 56 currmove c5c4 currmovenumber 1
bestmove c5c4 ponder f3e2
```
so retain the value from the last info line that contained the actual nodes.