### PR TITLE
check TB PV for correct ply distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench]
+usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--maxTBscore MAXTBSCORE] [--concurrency CONCURRENCY] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -35,6 +35,8 @@ options:
                         path(s) to syzygy EGTBs, with ':'/';' as separator on Linux/Windows (default: None)
   --minTBscore MINTBSCORE
                         lowest cp score for a TB win (default: 19754)
+  --maxTBscore MAXTBSCORE
+                        highest cp score for a TB win: if nonzero, it is assumed that (MAXTBSCORE - |score|) is distance to TB in plies (default: 20000)
   --concurrency CONCURRENCY
                         total number of threads script may use, default: cpu_count() (default: 8)
   --epdFile EPDFILE [EPDFILE ...]

--- a/matecheck.py
+++ b/matecheck.py
@@ -18,7 +18,7 @@ class TB:
             cum += c
             if cum == count + 1:  # KvK is not part of count
                 self.cardinality = idx + 2
-        assert self.cardinality > 2, "Only incommplete EGTBs found."
+        assert self.cardinality > 2, "Only incomplete EGTBs found."
 
     def probe(self, board):
         if board.castling_rights or chess.popcount(board.occupied) > self.cardinality:

--- a/matecheck.py
+++ b/matecheck.py
@@ -8,14 +8,20 @@ class TB:
     def __init__(self, path):
         self.tb = chess.syzygy.Tablebase()
         sep = ";" if sys.platform.startswith("win") else ":"
+        count = 0
         for d in path.split(sep):
-            self.tb.add_directory(d)
+            count += self.tb.add_directory(d, load_dtz=False)
+        print(f"Found {count} tablebases. ", end="")
+        file_counts = [1, 5, 30, 110, 365, 1001]  # https://oeis.org/A018213
+        self.cardinality = cum = 0
+        for idx, c in enumerate(file_counts):
+            cum += c
+            if cum == count + 1:  # KvK is not part of count
+                self.cardinality = idx + 2
+        assert self.cardinality > 2, "Only incommplete EGTBs found."
 
     def probe(self, board):
-        if (
-            board.castling_rights
-            or chess.popcount(board.occupied) > chess.syzygy.TBPIECES
-        ):
+        if board.castling_rights or chess.popcount(board.occupied) > self.cardinality:
             return None
         return self.tb.get_wdl(board)
 
@@ -26,10 +32,11 @@ def chunks(lst, n):
         yield lst[i : i + n]
 
 
-def pv_status(fen, mate, score, pv, tb=None):
+def pv_status(fen, mate, score, pv, tb=None, maxTBscore=0):
     # check if the given pv (list of uci moves) leads to checkmate #mate
     # if mate is None, check if pv leads to claimed TB win/loss
     losing_side = 1 if (mate and mate > 0) or (score and score > 0) else 0
+    plies_to_tb = 0
     try:
         board = chess.Board(fen)
         for ply, move in enumerate(pv):
@@ -38,7 +45,9 @@ def pv_status(fen, mate, score, pv, tb=None):
             # if EGTB is available, probe it to check PV correctness
             if tb is not None:
                 wdl = tb.probe(board)
-                if wdl is not None:
+                if wdl is None:
+                    plies_to_tb += 1
+                else:
                     if abs(wdl) != 2:
                         return "draw"
                     if ply % 2 == losing_side and wdl != -2:
@@ -66,6 +75,8 @@ def pv_status(fen, mate, score, pv, tb=None):
     wdl = tb.probe(board)
     if wdl is None:
         return "short"
+    if maxTBscore and plies_to_tb != maxTBscore - abs(score):
+        return "wrong"
     if abs(wdl) != 2:
         return "draw"
     if (ply + 1) % 2 == losing_side and wdl != -2:
@@ -187,6 +198,12 @@ if __name__ == "__main__":
         type=int,
         help="lowest cp score for a TB win",
         default=20000 - 246,  # for SF this is TB_CP - MAX_PLY
+    )
+    parser.add_argument(
+        "--maxTBscore",
+        type=int,
+        help="highest cp score for a TB win: if nonzero, it is assumed that (MAXTBSCORE - |score|) is distance to TB in plies",
+        default=20000,  # for SF this is TB_CP
     )
     parser.add_argument(
         "--concurrency",
@@ -317,7 +334,7 @@ if __name__ == "__main__":
         for _, _, pvstatus, _, _, _, _ in res:
             c += sum(1 for (_, score, _) in pvstatus if score is not None)
         if c:
-            print(f"\nChecking {c} TB win PVs. This may take some time...")
+            print(f"Checking {c} TB win PVs. This may take some time...\n")
 
     mates = bestmates = tbwins = 0
     issue = {
@@ -370,7 +387,9 @@ if __name__ == "__main__":
                 if score * bestmate > 0:
                     if last_line:
                         tbwins += 1
-                    status = pv_status(fen, mate, score, pv.split(), tb)
+                    status = pv_status(
+                        fen, mate, score, pv.split(), tb, args.maxTBscore
+                    )
                     if status != "ok" and not args.shortTBPVonly or status == "short":
                         issue["Bad PVs"][0] += 1
                         if not found_badpv or args.showAllIssues:


### PR DESCRIPTION
For engines like stockfish, which encode the distance to a TB win/loss by e.g. `20000 - |score|`, we can also check the correctness of the entry point into the EGTB when we check PVs.

Edit: Output for latest version is:
```
> python matecheck.py --engine ./stockfish --epdFile mates2000.epd --syzygyPath /disk2/syzygy/ --nodes 10000 
Loaded 2000 FENs, with max(abs(bm)) = 27.

Matetrack started for ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath /disk2/syzygy/ ...
100%|############################################| 100/100 [00:16<00:00,  6.21it/s]

Found 510 tablebases. Checking 2415 TB win PVs. This may take some time...

Found TB score -20000 with PV status "draw" for FEN "rr5k/RR6/7K/8/8/8/8/8 b - -" with bm #-6.
PV: h8g8 b7b8 a8b8
Found TB score 20000 with PV status "draw" for FEN "8/8/8/5K2/7k/7p/7N/7N w - -" with bm #9.
PV: h2f3 h4h5 h1g3 h5h6
Found TB score 19993 with PV status "draw" for FEN "8/5K2/8/8/8/B7/pn6/kb3R2 w - -" with bm #11.
PV: a3f8 b2d3 f8g7 d3b2 f1f2 b1c2 f2c2 a1b1 c2b2 b1a1 f7e7
Found TB score 19999 with PV status "draw" for FEN "8/8/8/4p3/4B3/2KN4/1Q6/5qk1 w - -" with bm #7.
PV: d3e5 f1e2 e5f3 g1h1 f3g5 h1g1 b2e2
Found TB score -19988 with PV status "wrong" for FEN "8/2p5/8/2p5/p3Q3/K7/2r5/1k6 b - -" with bm #-8.
PV: c7c6 e4h1 c2c1 h1h7 c1c2 h7e4 c5c4 e4e1 c2c1 e1b4 b1c2 b4c4 c2d2 c4f4 d2c2 f4b4
Found TB score -20000 with PV status "draw" for FEN "4N3/8/8/3p1p2/8/8/p7/k1K5 b - -" with bm #-6.
PV: f5f4 e8f6 f4f3 f6g4 d5d4
Found TB score 20000 with PV status "draw" for FEN "8/7n/7P/8/6nK/5k2/8/8 b - -" with bm #10.
PV: g4f6 h4h3 f6e4 h3h2 e4g5 h2h1 f3g3 h1g1
Found TB score -19992 with PV status "draw" for FEN "8/8/8/8/4N3/p1K1N3/p7/rk6 b - -" with bm #-10.
PV: b1c1 e4c5 c1b1 c3d2 b1b2 e3c4 b2b1 c4a3 b1b2 a3c4 b2b1 d2d3 b1c1 c5b3 c1d1
Found TB score 19999 with PV status "draw" for FEN "8/6R1/7p/5K1k/8/6p1/5b1P/8 w - -" with bm #10.
PV: h2g3 f2e1 g3g4 h5h4 g7d7 e1f2 d7d1 h4g3 d1d3 g3h4
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/1N5B/p7/4r3/k1K5 b - -" with bm #-8.
PV: e2e6 h4d8
Found TB score -20000 with PV status "draw" for FEN "1b6/2p5/8/2K5/k7/8/1PB5/8 b - -" with bm #-7.
PV: a4a5 b2b4 a5a6 c2d3 a6b7
Found TB score -20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/1Bp5/1b6 b - -" with bm #-6.
PV: a3a2 b6a4 c2c1b b2c1
Found TB score -20000 with PV status "draw" for FEN "Q7/8/8/8/8/8/6rp/4K2k b - -" with bm #-11.
PV: h1g1 a8a7 g1h1 a7f7
Found TB score -19992 with PV status "draw" for FEN "8/8/2N5/7K/4N3/6bk/8/5B1n b - -" with bm #-8.
PV: h3h2 c6d4 h2g1 f1h3 g1h2 h5g4 h1f2 e4f2 h2g1 f2e4 g3e1 d4f3 g1h1 e4g3 e1g3 g4g3
Found TB score -20000 with PV status "draw" for FEN "1b6/k1p5/2K2N2/8/8/8/8/5B2 b - -" with bm #-8.
PV: a7a8 f6d7 b8a7 c6c7
Found TB score -20000 with PV status "draw" for FEN "7k/8/4B1K1/8/4R3/1r6/8/8 b - -" with bm #-6.
PV: b3b4 e6g4 b4e4
Found TB score 19999 with PV status "draw" for FEN "5K1k/5PN1/7q/4Q3/8/6p1/8/8 w - -" with bm #7.
PV: e5g3 h6h7 g3h3 h7h3
Found TB score -20000 with PV status "draw" for FEN "8/8/8/8/2Q5/1qN5/k7/2K5 b - -" with bm #-7.
PV: a2a3 c3b1 b3b1 c1b1
Found TB score -20000 with PV status "draw" for FEN "8/p7/8/8/P7/3N4/5K1p/7k b - -" with bm #-6.
PV: a7a5 d3f4
Found TB score -20000 with PV status "draw" for FEN "8/8/N7/2B5/8/7p/5K1P/7k b - -" with bm #-7.
PV: h1h2 a6b4
Found TB score 19993 with PV status "draw" for FEN "k7/q2N4/3K4/8/8/6Q1/2p5/n7 w - -" with bm #13.
PV: g3g2 a7b7 g2g8 a8a7 g8g1 a7a6 g1a1 a6b5 a1f1 b5b4
Found TB score 20000 with PV status "draw" for FEN "8/2p5/8/2p5/8/7P/p2K4/k7 w - -" with bm #8.
PV: d2c1 c5c4 h3h4 c4c3 c1c2 c7c6 h4h5 c6c5
Found TB score 20000 with PV status "draw" for FEN "7k/8/4K3/5N2/3N4/4p3/8/8 w - -" with bm #9.
PV: d4e2 h8g8 e6e7 g8h8 e7f7 h8h7 e2f4 e3e2
Found TB score -19996 with PV status "draw" for FEN "8/8/8/4B3/4p3/4K2p/4b3/1R2k3 b - -" with bm #-6.
PV: e2d1 e5c3 e1f1 b1d1 f1g2 e3e4
Found TB score -20000 with PV status "draw" for FEN "8/1p6/8/2P5/8/8/p2K4/Bk6 b - -" with bm #-9.
PV: b1a1 d2c1
Found TB score 20000 with PV status "draw" for FEN "8/8/8/8/3N3N/4K2p/7p/7k w - -" with bm #9.
PV: e3e2 h1g1 d4f3 g1h1 f3h2 h1g1 h2f3 g1h1 e2f2 h3h2
Found TB score -19996 with PV status "draw" for FEN "8/8/8/8/2b1p3/3NB1K1/8/3B3k b - -" with bm #-6.
PV: c4d5 d3f2 h1g1 f2e4 g1f1 e4c3 d5g2 e3g5 f1e1 g3g2
Found TB score 20000 with PV status "draw" for FEN "8/8/6p1/4N3/6N1/8/5K2/7k w - -" with bm #7.
PV: e5f3 g6g5 g4e3
Found TB score 20000 with PV status "draw" for FEN "8/8/1N6/8/8/k1K5/2p5/Bb6 w - -" with bm #7.
PV: a1b2 a3a2 b6a4
Found TB score 20000 with PV status "draw" for FEN "7Q/8/8/8/8/8/6rp/4K2k w - -" with bm #12.
PV: h8a8 h1g1 a8a7 g1h1 a7a5 g2g3
Found TB score -19996 with PV status "draw" for FEN "8/3p4/8/4B3/8/8/r4p2/3R1K1k b - -" with bm #-8.
PV: a2c2 d1d3 c2c1 f1f2 c1c2 f2f3 c2g2 d3d1 g2g1 d1d7 g1f1 f3g4 h1g2 d7h7
Found TB score 19993 with PV status "draw" for FEN "8/7P/5r2/p4B2/p7/K7/8/k7 w - -" with bm #7.
PV: h7h8r f6h6 h8e8 h6h1 e8e2 h1h3 f5h3 a1b1 a3a4 b1c1 a4a5 c1d1 e2d2 d1d2
Found TB score -19996 with PV status "draw" for FEN "7k/8/5N1K/4B3/8/6pp/8/7b b - -" with bm #-8.
PV: g3g2 e5h2 g2g1r h2g1 h1a8 g1d4
Found TB score -20000 with PV status "draw" for FEN "7K/8/8/1p6/8/3N4/2N5/kB6 b - -" with bm #-11.
PV: a1b1 c2a3 b1a2
Found TB score -20000 with PV status "draw" for FEN "8/4p3/8/8/8/1N3p1p/5K2/7k b - -" with bm #-15.
PV: e7e6 b3d2 e6e5 d2f1 e5e4 f1g3 h1h2 g3e4 h2h1 e4f6
Found TB score -19998 with PV status "draw" for FEN "8/8/2p5/1kP5/1N6/1P1N4/1K6/8 b - -" with bm #-9.
PV: b5a5 b4c6 a5b5 c6d4 b5a5 b3b4 a5a4 c5c6
Found TB score -20000 with PV status "draw" for FEN "8/8/2Q5/8/8/7p/8/q2N1K1k b - -" with bm #-11.
PV: h1h2 c6c2 h2g3
Found TB score -20000 with PV status "draw" for FEN "1k6/8/3N4/1N6/6pK/8/8/7B b - -" with bm #-7.
PV: g4g3 h4g3
Found TB score -20000 with PV status "draw" for FEN "5k2/8/5Kp1/1q6/8/Q7/3p4/8 b - -" with bm #-15.
PV: f8g8 a3a2 g8h8 a2d2
Found TB score -20000 with PV status "draw" for FEN "8/8/6p1/8/2N3N1/8/5K2/7k b - -" with bm #-6.
PV: g6g5 c4d2
Found TB score 20000 with PV status "draw" for FEN "8/3p4/8/6n1/8/8/2R4p/5K1k w - -" with bm #12.
PV: c2c1 g5e4 c1e1
Found TB score -19998 with PV status "draw" for FEN "5K1k/5p1q/5B2/8/5P2/6P1/8/8 b - -" with bm #-9.
PV: h7g7 f6g7 h8h7 f8f7
Found TB score -20000 with PV status "draw" for FEN "7Q/8/8/8/8/1K6/pp6/kn6 b - -" with bm #-6.
PV: b1d2 b3a3 d2c4 a3b4 c4e3
Found TB score 20000 with PV status "draw" for FEN "1rr4k/1RR5/8/7K/8/8/8/8 w - -" with bm #7.
PV: h5h6 h8g8 c7g7 g8f8 b7f7 f8e8 f7e7 e8d8 e7a7

Using ./stockfish on mates2000.epd with --nodes 10000 --syzygyPath /disk2/syzygy/
Engine ID:     Stockfish dev-20240703-ee6fc7e3
Total FENs:    2000
Found mates:   350
Best mates:    297
Found TB wins: 301

Parsing the engine's full UCI output, the following issues were detected:
Bad PVs:       72   (from 44 FENs)
```

The only `wrong` status is for a PV which turns a win into a loss. But this will be fixed by https://github.com/official-stockfish/Stockfish/pull/5414.

Note that python-chess returns a successful wdl probe for 7men positions that have a winning capture into 6men land even when only 6men EGTBs are loaded. See https://github.com/niklasf/python-chess/discussions/1093. That means that master may miss some `short` PVs returned by the engines. This is also fixed with this PR.