### PR TITLE
correctly deal with castling rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ options:
   --minTBscore MINTBSCORE
                         lowest cp score for a TB win (default: 19754)
   --maxTBscore MAXTBSCORE
-                        highest cp score for a TB win: if nonzero, it is assumed that (MAXTBSCORE - |score|) is distance to TB in plies (default: 20000)
+                        highest cp score for a TB win: if nonzero, it is assumed that (MAXTBSCORE - |score|) is distance in plies to first zeroing move in(to) TB (default: 20000)
   --concurrency CONCURRENCY
                         total number of threads script may use, default: cpu_count() (default: 8)
   --epdFile EPDFILE [EPDFILE ...]


### PR DESCRIPTION
Credits to @vondele for this patch.

While testing https://github.com/official-stockfish/Stockfish/pull/5414 we realized that the scripts counting of the distance to TB was not quite correct,  and certainly not what SF does. This patch aligns the script with the correct counting of SF. It only affects positions with castling rights, and there it now counts the distance to the first zeroing move in(to) TB after castling.

The script in master would (wrongly) count the distance to the move after castling.