### PR TITLE
correct count in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ contains illegal moves or does not end in checkmate.
 
 ### List of available test suites
 
-* `ChestUCI_23102018.epd`: The original suite derived from publicly available `ChestUCI.epd` files, see [FishCooking](https://groups.google.com/g/fishcooking/c/lh1jTS4U9LU/m/zrvoYQZUCQAJ). It contains 6561 positions, with one definite and five likely draws, some illegal positions and some positions with a sub-optimal or likely incorrect value for the fastest known mate.
+* `ChestUCI_23102018.epd`: The original suite derived from publicly available `ChestUCI.epd` files, see [FishCooking](https://groups.google.com/g/fishcooking/c/lh1jTS4U9LU/m/zrvoYQZUCQAJ). It contains 6566 positions, with one definite and five likely draws, some illegal positions and some positions with a sub-optimal or likely incorrect value for the fastest known mate.
 * **`matetrack.epd`**: The successor to `ChestUCI_23102018.epd`, with all illegal positions removed and all known errors corrected. The plots shown above are based on this file. It contains 6554 mate problems, ranging from mate in 1 (#1) to #126 for positions with between 4 and 32 pieces. In 26 positions the side to move is going to get mated.
 * `matetrackpv.epd`: The same as `matetrack.epd`, but for each position the file also includes a PV leading to the checkmate, if such a PV is known.
 * `matedtrack.epd`: Derived from `matetrackpv.epd` by applying a best move in all those positions, where the winning side is to move, and where a best move is known. The order of the positions in `matedtrack.epd` corresponds 1:1 to the order in `matetrack.epd`. So the new test suite still contains 6554 mate problems, but for 6546 of them the side to move is going to get mated.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ contains illegal moves or does not end in checkmate.
 * `ChestUCI_23102018.epd`: The original suite derived from publicly available `ChestUCI.epd` files, see [FishCooking](https://groups.google.com/g/fishcooking/c/lh1jTS4U9LU/m/zrvoYQZUCQAJ). It contains 6566 positions, with one definite and five likely draws, some illegal positions and some positions with a sub-optimal or likely incorrect value for the fastest known mate.
 * **`matetrack.epd`**: The successor to `ChestUCI_23102018.epd`, with all illegal positions removed and all known errors corrected. The plots shown above are based on this file. It contains 6554 mate problems, ranging from mate in 1 (#1) to #126 for positions with between 4 and 32 pieces. In 26 positions the side to move is going to get mated.
 * `matetrackpv.epd`: The same as `matetrack.epd`, but for each position the file also includes a PV leading to the checkmate, if such a PV is known.
-* `matedtrack.epd`: Derived from `matetrackpv.epd` by applying a best move in all those positions, where the winning side is to move, and where a best move is known. The order of the positions in `matedtrack.epd` corresponds 1:1 to the order in `matetrack.epd`. So the new test suite still contains 6554 mate problems, but for 6546 of them the side to move is going to get mated.
+* `matedtrack.epd`: Derived from `matetrackpv.epd` by applying a best move in all those positions, where the winning side is to move, and where a best move is known. The order of the positions in `matedtrack.epd` corresponds 1:1 to the order in `matetrack.epd`. So the new test suite still contains 6554 mate problems, but for 6546 of them the side to move is going to get mated. Observe that due to duplications, only 6528 of the latter positions are unique.
 * `mates2000.epd`: A smaller test suite with 2000 positions ranging from #1 to #27. It contains a random selection of positions from `matetrack.epd` and `matedtrack.epd` that Stockfish can solve with 1M nodes. In 1105 positions the side to move is going to get mated.
 
 ### Automatic creation of new test positions
@@ -83,5 +83,5 @@ python advancepvs.py --plies 1 --mateType won && sed 's/; PV.*/;/' matedtrackpv.
 ```
 Similarly, a file with only `#-10` positions can be created with the command
 ```shell
-python advancepvs.py --targetMate -10 && grep 'bm #-10;' matedtrackpv.epd > mate-10.epd
+python advancepvs.py --targetMate -10 && grep 'bm #-10;' matedtrackpv.epd | awk -F'; PV' '\!seen[$1]++' > mate-10.epd
 ```


### PR DESCRIPTION
So inspired by https://github.com/robertnurnberg/matetools/pull/77, this PR makes three changes to the readme:

* fix the total count for the original ChestUCI suite
* mention the number of *unique* positions in `matedtrack.epd`
* fix the command line for the `mate-10.epd` example to avoid duplicates