### PR TITLE
add range info and relative change to recent plot

### DIFF
--- a/plotdata.py
+++ b/plotdata.py
@@ -96,6 +96,24 @@ class matedata:
                     s=bmateDotSize,
                 )
                 ax2.legend()
+            for Idx, (s, dat, col) in enumerate(
+                [("best mates", b, bmateColor), ("mates", m, mateColor)]
+            ):
+                datmin, datmax = min(dat), max(dat)
+                datmean = (datmin + datmax) // 2
+                datpct = datmax * 100 / max(datmean, 1) - 100
+                datStr = f"{s}$\subset$[{datmin},{datmax}]$\\approx${datmean}$\pm${datpct:.1f}%"
+                lenStr = len(datStr) - 20  # account for LaTeX commands
+                ax.text(
+                    0.055 + Idx * (0.94 - 0.012 * lenStr),
+                    0.02,
+                    datStr,
+                    transform=fig.transFigure,
+                    color=col,
+                    fontsize=7,
+                    family="monospace",
+                    weight="bold",
+                )
 
         # add release labels
         for i, txt in enumerate(t):


### PR DESCRIPTION
The change is only for the plot for the last 50 commits.

An example for the new plot is given below (which shows that within the last 50 commits there was a drop of roughly 10.2% in best mates and 8.4% in mates).

![matetrack1000000](https://github.com/user-attachments/assets/7e165d33-722e-46ec-89d9-27b5bfc221cb)
