### PR TITLE
check for mate scores outside the valid range

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--minTBscore MINTBSCORE] [--maxTBscore MAXTBSCORE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench]
+usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--mate MATE] [--hash HASH] [--threads THREADS] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -33,10 +33,16 @@ options:
   --threads THREADS     number of threads per position (values > 1 may lead to non-deterministic results) (default: None)
   --syzygyPath SYZYGYPATH
                         path(s) to syzygy EGTBs, with ':'/';' as separator on Linux/Windows (default: None)
-  --minTBscore MINTBSCORE
-                        lowest cp score for a TB win (default: 19754)
+  --syzygy50MoveRule SYZYGY50MOVERULE
+                        Count cursed wins as wins if set to "False". (default: None)
   --maxTBscore MAXTBSCORE
                         highest cp score for a TB win: if nonzero, it is assumed that (MAXTBSCORE - |score|) is distance in plies to first zeroing move in(to) TB (default: 20000)
+  --minTBscore MINTBSCORE
+                        lowest cp score for a TB win (default: 19754)
+  --maxValidMate MAXVALIDMATE
+                        highest possible mate score (default: 123)
+  --minValidMate MINVALIDMATE
+                        lowest possible mate score (default: -123)
   --concurrency CONCURRENCY
                         total number of threads script may use, default: cpu_count() (default: 32)
   --engineOpts ENGINEOPTS


### PR DESCRIPTION
This PR is inspired by https://github.com/official-stockfish/Stockfish/issues/6296.

To be able to catch such cases in future, we now also inspect mate values with `upperbound` and `lowerbound` flags.

The default values for `--maxValidMate` and `--minValidMate` are chosen to fit (current) Stockfish. For older/future versions, and other engines, these values may need to be adjusted.

Example (with artificially chosen valid mate score range of [-25,25]):
```
> python matecheck.py --nodes 100000 --maxValidMate 25 --minValidMate -25 --epdFile mates2000.epd
Loaded 2000 FENs, with max(|bm|) = 27.

Matetrack started for ./stockfish on mates2000.epd with --nodes 100000 ...
100%|###########################################| 33/33 [02:08<00:00,  3.90s/it]

Found invalid mate #-33 outside of [-25, 25] for FEN "5k2/1p3P2/1P2Pp2/pPp2Pp1/K1p3P1/2p2p2/2P2P2/8 b - -" with bm #-20.

Using ./stockfish on mates2000.epd with --nodes 100000
Engine ID:     Stockfish dev-20250907-c15133b7
Total FENs:    2000
Found mates:   1155
Best mates:    906

Parsing the engine's full UCI output, the following issues were detected:
Invalid mate scores: 3   (from 1 FENs)
```