### PR TITLE
fix timeout errors for large Hash values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE]
+usage: matecheck.py [-h] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
 options:
   -h, --help            show this help message and exit
   --engine ENGINE       name of the engine binary (default: ./stockfish)
+  --timeout TIMEOUT     parameter passed to chess.engine.SimpleEngine (default: None)
   --nodes NODES         nodes limit per position, default: 10**6 without other limits, otherwise None (default: None)
   --depth DEPTH         depth limit per position (default: None)
   --time TIME           time limit (in seconds) per position (default: None)

--- a/matecheck.py
+++ b/matecheck.py
@@ -104,6 +104,7 @@ def pv_status(fen, mate, score, pv, tb=None, maxTBscore=0):
 class Analyser:
     def __init__(self, args):
         self.engine = args.engine
+        self.timeout = args.timeout
         if args.timeinc is None:
             self.limit = chess.engine.Limit(
                 nodes=args.nodes,
@@ -131,11 +132,11 @@ class Analyser:
 
     def analyze_fens(self, fens):
         result_fens = []
-        engine = chess.engine.SimpleEngine.popen_uci(self.engine)
-        if self.hash is not None:
-            engine.configure({"Hash": self.hash})
+        engine = chess.engine.SimpleEngine.popen_uci(self.engine, timeout=self.timeout)
         if self.threads is not None:
             engine.configure({"Threads": self.threads})
+        if self.hash is not None:
+            engine.configure({"Hash": self.hash})
         if self.syzygyPath is not None:
             engine.configure({"SyzygyPath": self.syzygyPath})
         if self.syzygy50MoveRule is not None:
@@ -203,6 +204,11 @@ if __name__ == "__main__":
         "--engine",
         default="./stockfish",
         help="name of the engine binary",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="parameter passed to chess.engine.SimpleEngine",
     )
     parser.add_argument(
         "--nodes",


### PR DESCRIPTION
For large hash values, the 10s default timeout in `chess.engine.SimpleEngine` leads to time errors on my machines.

This PR sets the timeout to `None` as default, meaning timeouts are de-activated. The user can specify a finite timeout value through `--timeout`.

We also swap the order in which hash and threads are sent to the engine.
