### PR TITLE
Add more detailed bm statistics.

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -367,12 +367,15 @@ if __name__ == "__main__":
                     else:
                         fens[fen] = bm
 
-    maxbm = max([abs(bm) for bm in fens.values()]) if fens else 0
+    absbms = [abs(bm) for bm in fens.values()] if fens else [0]
+    maxbm = max(absbms)
     fens = list(fens.items())
     random.seed(42)
     random.shuffle(fens)  # try to balance the analysis time across chunks
 
-    print(f"Loaded {len(fens)} FENs, with max(|bm|) = {maxbm}.")
+    print(
+        f"Loaded {len(fens)} FENs, with |bm| (min avg max): {min(absbms)} {round(sum(absbms)/len(absbms))} {maxbm}."
+    )
 
     numfen = len(fens)
     workers = args.concurrency // (args.threads if args.threads else 1)
@@ -532,13 +535,14 @@ if __name__ == "__main__":
         for bm in range(maxbm + 1):
             if bestnodes[bm]:
                 nl, dl = bestnodes[bm], bestdepth[bm]
+                total = absbms.count(bm)
                 print(
-                    f"|bm| = {bm} - mates: {len(nl)}, nodes (min avg max): {min(nl)} {round(sum(nl)/len(nl))} {max(nl)}, depth (min avg max): {min(dl)} {round(sum(dl)/len(dl))} {max(dl)}"
+                    f"|bm| = {bm} - mates found: {len(nl)} = {(len(nl) * 1000 // total) / 10}% of {total}; nodes (min avg max): {min(nl)} {round(sum(nl)/len(nl))} {max(nl)}, depth (min avg max): {min(dl)} {round(sum(dl)/len(dl))} {max(dl)}"
                 )
         nl = [n for l in bestnodes for n in l]
         dl = [d for l in bestdepth for d in l]
         print(
-            f"All best mates: {len(nl)}, nodes (min avg max): {min(nl)} {round(sum(nl)/len(nl))} {max(nl)}, depth (min avg max): {min(dl)} {round(sum(dl)/len(dl))} {max(dl)}"
+            f"All best mates found: {len(nl)} = {(len(nl) * 1000 // numfen) / 10}% of {numfen}; nodes (min avg max): {min(nl)} {round(sum(nl)/len(nl))} {max(nl)}, depth (min avg max): {min(dl)} {round(sum(dl)/len(dl))} {max(dl)}"
         )
 
     if sum([v[0] for v in issue.values()]):


### PR DESCRIPTION
Changes to master:
* Rather than stating just `max(|bm|)`, we now state min, avg and max of the loaded FENs. Below this is `Loaded 1000 FENs, with |bm| (min avg max): 4 12 16.`
* In the best mate statistics, we now also say what percentage of the mates with that `|bm|` were found. E.g. `|bm| = 8 - mates found: 36 = 69.2% of 52;` in the below.

Example run:
```
> python matecheck.py --engine ./sf17.1 --epdFile KRvK_1000pv.epd --mate 0 --nodes "10**6"
Loaded 1000 FENs, with |bm| (min avg max): 4 12 16.

Matetrack started for ./sf17.1 on KRvK_1000pv.epd with --nodes 1000000 --mate 0 ...
100%|###########################################| 33/33 [02:57<00:00,  5.39s/it]


Using ./sf17.1 on KRvK_1000pv.epd with --nodes 1000000 --mate 0
Engine ID:     Stockfish 17.1
Total FENs:    1000
Found mates:   740
Best mates:    233

Best mate statistics:
|bm| = 4 - mates found: 7 = 100.0% of 7; nodes (min avg max): 8149 20181 48070, depth (min avg max): 15 22 28
|bm| = 5 - mates found: 8 = 100.0% of 8; nodes (min avg max): 2405 25214 75582, depth (min avg max): 11 22 37
|bm| = 6 - mates found: 13 = 100.0% of 13; nodes (min avg max): 21581 74931 210038, depth (min avg max): 19 30 44
|bm| = 7 - mates found: 14 = 100.0% of 14; nodes (min avg max): 14115 147796 302042, depth (min avg max): 16 30 43
|bm| = 8 - mates found: 36 = 69.2% of 52; nodes (min avg max): 27517 303876 901148, depth (min avg max): 17 36 60
|bm| = 9 - mates found: 37 = 64.9% of 57; nodes (min avg max): 81045 389778 984227, depth (min avg max): 17 38 61
|bm| = 10 - mates found: 38 = 50.0% of 76; nodes (min avg max): 63118 429139 1000581, depth (min avg max): 18 38 59
|bm| = 11 - mates found: 22 = 22.2% of 99; nodes (min avg max): 192932 546002 1000539, depth (min avg max): 24 39 49
|bm| = 12 - mates found: 31 = 20.6% of 150; nodes (min avg max): 94780 575898 1000184, depth (min avg max): 20 41 49
|bm| = 13 - mates found: 18 = 10.1% of 178; nodes (min avg max): 298955 749205 1000077, depth (min avg max): 25 42 54
|bm| = 14 - mates found: 7 = 3.2% of 213; nodes (min avg max): 520188 721907 948111, depth (min avg max): 34 42 47
|bm| = 15 - mates found: 2 = 1.7% of 113; nodes (min avg max): 847304 865128 882952, depth (min avg max): 40 44 47
All best mates found: 233 = 23.3% of 1000; nodes (min avg max): 2405 408537 1000581, depth (min avg max): 11 37 61
```

I plan to use this kind of output soon in a detailed comparison of sf-dev with older SF versions and other engines when it comes to mate finding in KRvK, KBNvK and KBBvK positions.