### PR TITLE
Introduce --bmMin and --bmMax

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE]
+usage: matecheck.py [-h] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--bmMin BMMIN] [--bmMax BMMAX] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -52,6 +52,8 @@ options:
                         json encoded dictionary of generic options, e.g. tuning parameters, to be used to initialize the engine (default: None)
   --epdFile EPDFILE [EPDFILE ...]
                         file(s) containing the positions and their mate scores (default: ['matetrack.epd'])
+  --bmMin BMMIN         lower limit for |bm| for positions to analyse (default: None)
+  --bmMax BMMAX         upper limit for |bm| for positions to analyse (default: None)
   --showAllIssues       show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue (default: False)
   --shortTBPVonly       for TB win scores, only consider short PVs an issue (default: False)
   --showAllStats        show nodes and depth statistics for best mates found (always True if --mate is supplied) (default: False)

--- a/matecheck.py
+++ b/matecheck.py
@@ -290,6 +290,16 @@ if __name__ == "__main__":
         help="file(s) containing the positions and their mate scores",
     )
     parser.add_argument(
+        "--bmMin",
+        type=int,
+        help="lower limit for |bm| for positions to analyse",
+    )
+    parser.add_argument(
+        "--bmMax",
+        type=int,
+        help="upper limit for |bm| for positions to analyse",
+    )
+    parser.add_argument(
         "--showAllIssues",
         action="store_true",
         help="show all unique UCI info lines with an issue, by default show for each FEN only the first occurrence of each possible type of issue",
@@ -356,6 +366,10 @@ if __name__ == "__main__":
                     fen, bm = m.group(1), int(m.group(2))
                     if unlimited and args.mate < abs(bm):
                         continue  # avoid analyses that cannot terminate
+                    if (args.bmMin is not None and abs(bm) < args.bmMin) or (
+                        args.bmMax is not None and abs(bm) > args.bmMax
+                    ):
+                        continue
                     if fen in fens:
                         bmold = fens[fen]
                         if bm != bmold:
@@ -389,6 +403,8 @@ if __name__ == "__main__":
         print("Additional generic engine options: ", args.engineOpts)
 
     limits = [
+        ("bmMin", args.bmMin),
+        ("bmMax", args.bmMax),
         ("nodes", args.nodes),
         ("depth", args.depth),
         ("time", args.time),


### PR DESCRIPTION
As discussed on discord.

Example:
```
> python matecheck.py --epdFile mates2000.epd --bmMin 4 --bmMax 7
Loaded 1092 FENs, with |bm| (min avg max): 4 6 7.

Matetrack started for ./stockfish on mates2000.epd with --bmMin 4 --bmMax 7 --nodes 1000000 ...

Using ./stockfish on mates2000.epd with --bmMin 4 --bmMax 7 --nodes 1000000
Engine ID:     Stockfish dev-20260426-1a882efc
Total FENs:    1092
Found mates:   958
Best mates:    872
```

Default behaviour unaffected.