### PR TITLE
Introduce option --foundMatesFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and is visualized in the graphs below.
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--bmMin BMMIN] [--bmMax BMMAX] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE]
+usage: matecheck.py [-h] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--syzygyPath SYZYGYPATH] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--epdFile EPDFILE [EPDFILE ...]] [--bmMin BMMIN] [--bmMax BMMAX] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE] [--foundMatesFile FOUNDMATESFILE]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -59,6 +59,8 @@ options:
   --showAllStats        show nodes and depth statistics for best mates found (always True if --mate is supplied) (default: False)
   --bench               provide cumulative statistics for nodes searched and time used (default: False)
   --logFile LOGFILE     optional file to log the engine's output while it is analysing (default: None)
+  --foundMatesFile FOUNDMATESFILE
+                        optional file to save the positions the engine found a mate for (default: None)
 ```
 
 Sample output:

--- a/matecheck.py
+++ b/matecheck.py
@@ -70,7 +70,7 @@ def pv_status(fen, mate, score, pv, tb=None, maxTBscore=0):
                     if ply % 2 != losing_side and wdl != 2:
                         return f"wrong: wdl = {wdl} != 2 at ply {ply} for {board.epd()}"
             uci = chess.Move.from_uci(move)
-            if not uci in board.legal_moves:
+            if uci not in board.legal_moves:
                 raise Exception(f"illegal move {move} at position {board.epd()}")
             board.push(uci)
     except Exception as ex:
@@ -323,6 +323,10 @@ if __name__ == "__main__":
         "--logFile",
         help="optional file to log the engine's output while it is analysing",
     )
+    parser.add_argument(
+        "--foundMatesFile",
+        help="optional file to save the positions the engine found a mate for",
+    )
     args = parser.parse_args()
     if (
         args.nodes is None
@@ -355,7 +359,7 @@ if __name__ == "__main__":
         args.mate and args.nodes is None and args.depth is None and args.time is None
     )
 
-    fens = {}
+    bmfens = {}
     for epd in args.epdFile:
         with open(epd) as f:
             for line in f:
@@ -370,20 +374,20 @@ if __name__ == "__main__":
                         args.bmMax is not None and abs(bm) > args.bmMax
                     ):
                         continue
-                    if fen in fens:
-                        bmold = fens[fen]
+                    if fen in bmfens:
+                        bmold = bmfens[fen]
                         if bm != bmold:
                             print(
                                 f'Warning: For duplicate FEN "{fen}" we only keep faster mate between #{bm} and #{bmold}.'
                             )
                             if abs(bm) < abs(bmold):
-                                fens[fen] = bm
+                                bmfens[fen] = bm
                     else:
-                        fens[fen] = bm
+                        bmfens[fen] = bm
 
-    absbms = [abs(bm) for bm in fens.values()] if fens else [0]
+    absbms = [abs(bm) for bm in bmfens.values()] if bmfens else [0]
     maxbm = max(absbms)
-    fens = list(fens.items())
+    fens = list(bmfens.items())
     random.seed(42)
     random.shuffle(fens)  # try to balance the analysis time across chunks
 
@@ -462,6 +466,7 @@ if __name__ == "__main__":
     }
     bestnodes = [[] for _ in range(maxbm + 1)]
     bestdepth = [[] for _ in range(maxbm + 1)]
+    foundmates = {}
     for fen, bestmate, pvstatus, nodes, depth, _, _ in res:
         found_invalid = found_better = found_wrong = False
         found_badpv = found_wrong_tb = False
@@ -480,6 +485,7 @@ if __name__ == "__main__":
                 if mate * bestmate > 0:
                     if last_line:  #  for mate counts use last valid UCI info output
                         mates += 1
+                        foundmates[fen] = mate
                         if mate == bestmate:
                             bestmates += 1
                             bestnodes[abs(mate)].append(nodes)
@@ -581,3 +587,12 @@ if __name__ == "__main__":
         print("Nodes searched  :", totalnodes)
         if totaltime > 0:
             print("Nodes/second    :", round(totalnodes / totaltime))
+
+    if args.foundMatesFile:
+        with open(args.foundMatesFile, "w") as f:
+            for fen, bm in bmfens.items():
+                if fen not in foundmates:
+                    continue
+                m = foundmates.pop(fen)  # to avoid duplicate output
+                txt = "Found best mate" if m == bm else f"Found mate #{m}"
+                f.write(f'{fen} bm #{bm}; c0 "{txt}"\n')


### PR DESCRIPTION
May be useful if we want to find all the positions in a collection that sf17 and sf17.1 find a mate for with a budget of 1m nodes, say. (Would need two successive runs with the new option.)

Example:
```
> python matecheck.py --nodes 100 --foundMatesFile found.epd
Loaded 6554 FENs, with |bm| (min avg max): 1 11 126.

Matetrack started for ./stockfish on matetrack.epd with --nodes 100 ...

Using ./stockfish on matetrack.epd with --nodes 100
Engine ID:     Stockfish dev-20260504-5095cd16
Total FENs:    6554
Found mates:   11
Best mates:    11
> wc -l found.epd && tail -n1 found.epd
11 found.epd
2rq4/3rk3/3bn1Bp/2Np1bP1/3N4/1p6/1K6/Bn6 w - - bm #10; c0 "Found best mate"
```