### PR TITLE
No longer count mates superseeded by inexact scores

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -167,6 +167,7 @@ class Analyser:
                         temp_score = info["score"].pov(board.turn)
                         temp_m = temp_score.mate()
                         temp_score = temp_score.score()
+                        m = score = None
                         if "upperbound" in info or "lowerbound" in info:
                             if temp_m:
                                 pvstatus[temp_m, None, "bound"] = "", False
@@ -177,6 +178,7 @@ class Analyser:
                             or score is None
                             or abs(score) < self.minTBscore
                         ):
+                            score = None
                             continue
                         pv = [m.uci() for m in info["pv"]] if "pv" in info else []
                         pvstr = " ".join(pv)


### PR DESCRIPTION
I stumbled upon this while working on a patch to also analyse MultiPV PVs for correctness.

I am not sure we ever consciously decided this: but master will count as found mate also a puzzle where the final info line of the engine is a bound score. I believe it is more consistent to only accept mate scores as found if the final info line contains it as an exact score.

This will slightly change most of the historical data, unfortunately. I can look into updating at least the recent classic280.epd data set quite soon.

Edit: The behaviour in master is a leftover from a time where we filtered out bound scores altogether. See the status before #135. I still think it is good to change now.

Edit2: The ignoring of bound scores was first introduced in #79, see also #78 and #77. I believe it was an oversight in #79 not to adapt the lastline logic as well.