### PR TITLE
Show missing mates in go-mate searches

### DIFF
--- a/matecheck.py
+++ b/matecheck.py
@@ -488,6 +488,7 @@ if __name__ == "__main__":
     bestdepth = [[] for _ in range(maxbm + 1)]
     foundmates = {}
     for fen, bestmate, pvstatus, nodes, depth, _, _ in res:
+        found_mate = None
         found_issues = set()
 
         def record_issue(multipv, key, txt):
@@ -516,6 +517,7 @@ if __name__ == "__main__":
                             bestmates += 1
                             bestnodes[abs(mate)].append(nodes)
                             bestdepth[abs(mate)].append(depth)
+                        found_mate = mate
                     if abs(mate) < abs(bestmate) and (multipv == 1 or mate > 0):
                         txt = f'Found mate #{mate} (better) for FEN "{fen}" with bm #{bestmate}.\nPV: {pv}'
                         record_issue(multipv, "Better mates", txt)
@@ -544,6 +546,13 @@ if __name__ == "__main__":
                 elif multipv == 1 or score > 0:
                     txt = f'Found TB score {score} (wrong sign) for FEN "{fen}" with bm #{bestmate}.\nPV: {pv}'
                     record_issue(multipv, "Wrong TB score", txt)
+        if args.mate is not None:
+            if found_mate is None:
+                print(f'Did not find mate for FEN "{fen}" with bm #{bestmate}.')
+            elif found_mate != bestmate:
+                print(
+                    f'Only found mate #{found_mate} for FEN "{fen}" with bm #{bestmate}.'
+                )
 
     print(f"\nUsing {msg}")
     if name:


### PR DESCRIPTION
Makes it easier to debug engine that fail the `go mate` part of the new `check_engine.sh` script. 

Sample usage:
```
> python matecheck.py --engine ../reckless/reckless --nodes "10**8" --mate 0 --bmMax 2 --epdFile matetrack.epd matedtrack.epd
Loaded 61 FENs, with |bm| (min avg max): 1 2 2.

Matetrack started for ../reckless/reckless on matetrack.epd matedtrack.epd with --bmMax 2 --nodes 100000000 --mate 0 ...
100%|âââââââââââââââââââââââââââââââââââââââââââ| 61/61 [02:21<00:00,  2.31s/it]

Only found mate #-8 for FEN "8/4p3/3R4/n7/rp6/kp5Q/8/1K6 b - -" with bm #-2.
Only found mate #-4 for FEN "K1R5/1P1r1n2/1p4N1/2R1p2r/1BpkBp1N/1bp2Q2/2P2P2/1n2b3 b - -" with bm #-2.

Using ../reckless/reckless on matetrack.epd matedtrack.epd with --bmMax 2 --nodes 100000000 --mate 0
Engine ID:     Reckless 0.10.0-dev-fec90982
Total FENs:    61
Found mates:   61
Best mates:    59

Best mate statistics:
|bm| = 1 - mates found: 21 = 100.0% of 21; nodes (min avg max): 482 6556 44874, depth (min avg max): 239 239 239
|bm| = 2 - mates found: 38 = 95.0% of 40; nodes (min avg max): 5412 45341203 100000002, depth (min avg max): 111 143 239
All best mates found: 59 = 96.7% of 61; nodes (min avg max): 482 29205142 100000002, depth (min avg max): 111 177 239
```