### PR TITLE
Introduce option --missedMatesFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ with the raw data in [`classic1000000.csv`](classic1000000.csv).
 ### Usage of `matecheck.py`
 
 ```
-usage: matecheck.py [-h] [--epdFile EPDFILE [EPDFILE ...]] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--multipvFile MULTIPVFILE [MULTIPVFILE ...]] [--syzygyPath SYZYGYPATH] [--evalFile EVALFILE] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--bmMin BMMIN] [--bmMax BMMAX] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE] [--foundMatesFile FOUNDMATESFILE]
+usage: matecheck.py [-h] [--epdFile EPDFILE [EPDFILE ...]] [--engine ENGINE] [--timeout TIMEOUT] [--nodes NODES] [--depth DEPTH] [--time TIME] [--timeinc TIMEINC] [--mate MATE] [--hash HASH] [--threads THREADS] [--multiPV MULTIPV] [--multipvFile MULTIPVFILE [MULTIPVFILE ...]] [--syzygyPath SYZYGYPATH] [--evalFile EVALFILE] [--syzygy50MoveRule SYZYGY50MOVERULE] [--maxTBscore MAXTBSCORE] [--minTBscore MINTBSCORE] [--maxValidMate MAXVALIDMATE] [--minValidMate MINVALIDMATE] [--concurrency CONCURRENCY] [--engineOpts ENGINEOPTS] [--bmMin BMMIN] [--bmMax BMMAX] [--showAllIssues] [--shortTBPVonly] [--showAllStats] [--bench] [--logFile LOGFILE] [--foundMatesFile FOUNDMATESFILE] [--missedMatesFile MISSEDMATESFILE]
 
 Check how many (best) mates an engine finds in e.g. matetrack.epd, a file with lines of the form "FEN bm #X;".
 
@@ -82,6 +82,8 @@ options:
   --logFile LOGFILE     optional file to log the engine's output while it is analysing (default: None)
   --foundMatesFile FOUNDMATESFILE
                         optional file to save the positions the engine found a mate for (default: None)
+  --missedMatesFile MISSEDMATESFILE
+                        optional file to save the positions the engine found no mate for (default: None)
 ```
 
 Sample output:

--- a/matecheck.py
+++ b/matecheck.py
@@ -380,6 +380,10 @@ if __name__ == "__main__":
         "--foundMatesFile",
         help="optional file to save the positions the engine found a mate for",
     )
+    parser.add_argument(
+        "--missedMatesFile",
+        help="optional file to save the positions the engine found no mate for",
+    )
     args = parser.parse_args()
     if (
         args.nodes is None
@@ -524,6 +528,7 @@ if __name__ == "__main__":
     bestnodes = [[] for _ in range(maxbm + 1)]
     bestdepth = [[] for _ in range(maxbm + 1)]
     foundmates = {}
+    missedmates = set()
     for fen, bestmate, pvstatus, nodes, depth, _, _ in res:
         found_mate = None
         found_issues = set()
@@ -592,7 +597,11 @@ if __name__ == "__main__":
                 else:
                     txt = f"Found TB score {score} (unexpected)"
                     record_issue(multipv, "Unexpected TB scores", txt, fen, bestmate)
-        if args.mate is not None:
+
+        if found_mate is None:
+            missedmates.add(fen)
+
+        if args.mate == 0:
             if found_mate is None:
                 print(f'Did not find mate for FEN "{fen}" with bm #{bestmate}.')
             elif found_mate != bestmate:
@@ -709,3 +718,11 @@ if __name__ == "__main__":
                 m = foundmates.pop(fen)  # to avoid duplicate output
                 txt = "Found best mate" if m == bm else f"Found mate #{m}"
                 f.write(f'{fen} bm #{bm}; c0 "{txt}"\n')
+
+    if args.missedMatesFile:
+        with open(args.missedMatesFile, "w") as f:
+            for fen, bm in bmfens.items():
+                if fen not in missedmates:
+                    continue
+                missedmates.remove(fen)  # to avoid duplicate output
+                f.write(f"{fen} bm #{bm};\n")


### PR DESCRIPTION
Sample usage:
```
> python matecheck.py --bmMax 2 --missedMatesFile missed.epd 
Loaded 21 FENs with 21 bm values, with |bm| (min avg max): 1 2 2.

Matetrack started for ./stockfish on matetrack.epd with --bmMax 2 --nodes 1000000 ...
100%|###########################################| 21/21 [00:04<00:00,  5.17it/s]


Using ./stockfish on matetrack.epd with --bmMax 2 --nodes 1000000
Engine ID:     Stockfish dev-20260810-5062aee5
Total FENs:    21
Found mates:   19
Best mates:    19

> cat missed.epd 
3N3K/B2bRB2/1Qp4p/1R1pppp1/1P2k3/r3pNP1/2P1P3/b2r3q w - - bm #2;
8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - - bm #2;
```