### PR TITLE
Use 1000 go-mate positions in check_engine.sh

### DIFF
--- a/check_engine.sh
+++ b/check_engine.sh
@@ -185,7 +185,10 @@ run_suite() {
     if [ "$GOMATENODES" -eq "0" ]; then
       echo -e "\n${BOLD}--- Skipping: th$th go-mate$egtb ---$NOCOL"
     else
-      run_test "th$th go-mate$egtb" "matecheck${th}gm$suffix" "${SYZYGY_ARGS[@]}" "${FLAG_ARGS[@]}" --engine "$ENGINE" --epdFile matetrack.epd matedtrack.epd --bmMax 2 --mate 0 --nodes "$GOMATENODES" --threads "$th"
+      python advancepvs.py --targetMate -2 --outFile mates2all.epd > /dev/null
+      head -n 1003 mates2all.epd > mates2head.epd
+      run_test "th$th go-mate$egtb" "matecheck${th}gm$suffix" "${SYZYGY_ARGS[@]}" "${FLAG_ARGS[@]}" --engine "$ENGINE" --epdFile mates2head.epd --bmMax 2 --mate 0 --nodes "$GOMATENODES" --threads "$th"
+      rm -rf mates2all.epd mates2head.epd
 
       total=$(grep "Total FENs:" "matecheck${th}gm$suffix" | awk '{print $3}')
       bmates=$(grep "Best mates:" "matecheck${th}gm$suffix" | awk '{print $3}')


### PR DESCRIPTION
This should make failures of the `go mate` test less random and make debugging and fixing of engines easier.

Snippet from running the new script:
```
--- Running: th1 gameplay ---
Loaded 2000 FENs with 2000 bm values, with |bm| (min avg max): 1 8 27.

Matetrack started for ./stockfish on mates2000.epd with --time 3.0 --timeinc 0.01 --threads 1 ...
100%|###########################################| 33/33 [00:45<00:00,  1.37s/it]


Using ./stockfish on mates2000.epd with --time 3.0 --timeinc 0.01 --threads 1
Engine ID:     Stockfish dev-20260810-5062aee5
Total FENs:    2000
Found mates:   361
Best mates:    246

--- Running: th1 go-mate ---
Loaded 1000 FENs with 1000 bm values, with |bm| (min avg max): 1 2 2.

Matetrack started for ./stockfish on mates2head.epd with --bmMax 2 --nodes 100000000 --mate 0 --threads 1 ...
100%|###########################################| 33/33 [03:44<00:00,  6.81s/it]

Did not find mate for FEN "8/6p1/6p1/4p1p1/4PkB1/Q3NP1K/q6p/6br b - -" with bm #-2.

Using ./stockfish on mates2head.epd with --bmMax 2 --nodes 100000000 --mate 0 --threads 1
Engine ID:     Stockfish dev-20260810-5062aee5
Total FENs:    1000
Found mates:   999
Best mates:    999

Best mate statistics:
|bm| = 1 - mates found: 4 = 100.0% of 4; nodes (min avg max): 4 68 217, depth (min avg max): 1 1 1
|bm| = 2 - mates found: 995 = 99.8% of 996; nodes (min avg max): 4 167853 33800661, depth (min avg max): 1 8 86
All best mates found: 999 = 99.9% of 1000; nodes (min avg max): 4 167181 33800661, depth (min avg max): 1 8 86
ERROR: At least one go-mate search did not yield the expected mate within 100000000 nodes. (Expected: 1000, Found: 999)
```